### PR TITLE
feat: implement persistent global dark mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "react-icons": "^5.6.0",
         "react-router-dom": "^7.14.2",
         "sonner": "^2.0.7"
       },
@@ -2509,6 +2510,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-icons": "^5.6.0",
     "react-router-dom": "^7.14.2",
     "sonner": "^2.0.7"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,20 +5,23 @@ import Dashboard from "./pages/Dashboard";
 import AddTasks from "./pages/AddTasks";
 import ListTasks from "./pages/ListTasks";
 import DeleteHistory from "./pages/DeleteHistory";
+import { ThemeProvider } from "./context/ThemeContext";
 import "./index.css";
 
 function App() {
   return (
-    <Router>
-      <Toaster position="bottom-right" />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/add-tasks" element={<AddTasks />} />
-        <Route path="/list-tasks" element={<ListTasks />} />
-        <Route path="/delete-history" element={<DeleteHistory />} />
-      </Routes>
-    </Router>
+    <ThemeProvider>
+      <Router>
+        <Toaster position="bottom-right" />
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/add-tasks" element={<AddTasks />} />
+          <Route path="/list-tasks" element={<ListTasks />} />
+          <Route path="/delete-history" element={<DeleteHistory />} />
+        </Routes>
+      </Router>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,22 @@
+import { FaMoon, FaSun } from "react-icons/fa";
+import { useTheme } from "../context/ThemeContext";
+
+const ThemeToggle = () => {
+  const { dark, toggleTheme } = useTheme();
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className={`flex items-center gap-2 px-4 py-2 rounded-full font-black text-xs uppercase tracking-widest border transition-all duration-200 hover:scale-105 ${
+        dark
+          ? "bg-white text-black border-white hover:bg-gray-100"
+          : "bg-black text-white border-black hover:bg-neutral-800"
+      }`}
+    >
+      {dark ? <FaSun className="w-3 h-3" /> : <FaMoon className="w-3 h-3" />}
+      {dark ? "Light Mode" : "Dark Mode"}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/context/ThemeContext.jsx
+++ b/src/context/ThemeContext.jsx
@@ -1,0 +1,24 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [dark, setDark] = useState(() => {
+    return localStorage.getItem("theme") === "dark";
+  });
+
+  useEffect(() => {
+    localStorage.setItem("theme", dark ? "dark" : "light");
+    document.documentElement.classList.toggle("dark", dark);
+  }, [dark]);
+
+  const toggleTheme = () => setDark((prev) => !prev);
+
+  return (
+    <ThemeContext.Provider value={{ dark, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/src/pages/AddTasks.jsx
+++ b/src/pages/AddTasks.jsx
@@ -1,8 +1,11 @@
 import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { toast } from "sonner";
+import { useTheme } from "../context/ThemeContext";
+import ThemeToggle from "../components/ThemeToggle";
 
 const AddTasks = () => {
+  const { dark } = useTheme();
   const [task, setTask] = useState("");
   const [category, setCategory] = useState("FEATURE");
   const [tasks, setTasks] = useState(() => {
@@ -36,30 +39,30 @@ const AddTasks = () => {
   };
 
   return (
-    <div className="min-h-screen bg-[#FDFDFD] flex items-center justify-center p-6 selection:bg-black selection:text-white font-sans antialiased">
-      <div className="w-full max-w-[480px] bg-white rounded-5xl p-12 shadow-[0_50px_100px_-20px_rgba(0,0,0,0.06)] border border-neutral-100 flex flex-col items-center text-center relative overflow-hidden">
+    <div className={`min-h-screen flex items-center justify-center p-6 selection:bg-black selection:text-white font-sans antialiased transition-colors duration-300 ${dark ? "bg-zinc-950" : "bg-[#FDFDFD]"}`}>
+      <div className={`w-full max-w-[480px] rounded-5xl p-12 shadow-[0_50px_100px_-20px_rgba(0,0,0,0.06)] border flex flex-col items-center text-center relative overflow-hidden transition-colors duration-300 ${dark ? "bg-zinc-900 border-zinc-700" : "bg-white border-neutral-100"}`}>
         {/* Top Accent */}
-        <div className="absolute top-0 left-0 w-full h-1.5 bg-black"></div>
+        <div className="absolute top-0 left-0 w-full h-1.5 bg-black dark:bg-white" />
+
+        {/* Theme Toggle */}
+        <div className="absolute top-6 right-6">
+          <ThemeToggle />
+        </div>
 
         {/* Icon Header */}
-        <div className="w-20 h-20 bg-black rounded-3xl flex items-center justify-center mb-10 shadow-2xl shadow-black/20 group hover:scale-105 transition-transform duration-500 cursor-pointer">
+        <div className={`w-20 h-20 rounded-3xl flex items-center justify-center mb-10 shadow-2xl shadow-black/20 group hover:scale-105 transition-transform duration-500 cursor-pointer ${dark ? "bg-white" : "bg-black"}`}>
           <svg
-            className="w-10 h-10 text-white"
+            className={`w-10 h-10 ${dark ? "text-black" : "text-white"}`}
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2.5}
-              d="M12 4v16m8-8H4"
-            />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 4v16m8-8H4" />
           </svg>
         </div>
 
         <div className="space-y-3 mb-12">
-          <h1 className="text-4xl font-black text-black tracking-tight uppercase">
+          <h1 className={`text-4xl font-black tracking-tight uppercase ${dark ? "text-white" : "text-black"}`}>
             Add Task
           </h1>
           <p className="text-neutral-400 font-medium text-lg">
@@ -82,7 +85,7 @@ const AddTasks = () => {
               value={task}
               onChange={(e) => setTask(e.target.value)}
               placeholder="e.g. Optimize database queries"
-              className="w-full bg-neutral-50 border-2 border-transparent rounded-4xl px-8 py-5 text-black placeholder:text-neutral-300 focus:bg-white focus:border-black transition-all duration-300 outline-none font-semibold text-lg shadow-sm"
+              className={`w-full border-2 border-transparent rounded-4xl px-8 py-5 placeholder:text-neutral-300 focus:border-current transition-all duration-300 outline-none font-semibold text-lg shadow-sm ${dark ? "bg-zinc-800 text-white focus:bg-zinc-700" : "bg-neutral-50 text-black focus:bg-white focus:border-black"}`}
               autoFocus
             />
           </div>
@@ -100,7 +103,9 @@ const AddTasks = () => {
                   onClick={() => setCategory(opt)}
                   className={`px-3 py-1 rounded-full text-xs font-black uppercase tracking-widest transition-all duration-200 cursor-pointer border ${
                     category === opt
-                      ? "bg-black text-white"
+                      ? "bg-black text-white border-black"
+                      : dark
+                      ? "bg-zinc-700 text-neutral-300 border-transparent hover:bg-zinc-600"
                       : "bg-neutral-100 text-neutral-600 border-transparent hover:bg-neutral-200"
                   }`}
                 >
@@ -112,23 +117,18 @@ const AddTasks = () => {
 
           <button
             type="submit"
-            className="group w-full bg-black text-white font-black py-6 rounded-4xl shadow-2xl shadow-black/40 hover:bg-neutral-800 active:scale-[0.98] transition-all duration-500 flex items-center justify-center space-x-4 text-xl tracking-wide"
+            className={`group w-full font-black py-6 rounded-4xl shadow-2xl active:scale-[0.98] transition-all duration-500 flex items-center justify-center space-x-4 text-xl tracking-wide ${dark ? "bg-white text-black hover:bg-gray-100 shadow-white/20" : "bg-black text-white hover:bg-neutral-800 shadow-black/40"}`}
           >
             <span>CREATE TASK</span>
 
             <div className="bg-white/20 p-2 rounded-full group-hover:translate-x-1 transition-transform duration-300">
               <svg
-                className="w-6 h-6 text-white"
+                className={`w-6 h-6 ${dark ? "text-black" : "text-white"}`}
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={3}
-                  d="M13 7l5 5m0 0l-5 5m5-5H6"
-                />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M13 7l5 5m0 0l-5 5m5-5H6" />
               </svg>
             </div>
           </button>
@@ -136,7 +136,7 @@ const AddTasks = () => {
 
         <Link
           to="/dashboard"
-          className="mt-12 text-neutral-400 hover:text-black font-bold text-sm uppercase tracking-widest transition-all duration-300 flex items-center space-x-2"
+          className={`mt-12 font-bold text-sm uppercase tracking-widest transition-all duration-300 flex items-center space-x-2 ${dark ? "text-neutral-400 hover:text-white" : "text-neutral-400 hover:text-black"}`}
         >
           <span>←</span>
           <span>Back to Dashboard</span>
@@ -144,8 +144,8 @@ const AddTasks = () => {
       </div>
 
       {/* Decorative Blur Elements */}
-      <div className="fixed top-[-10%] right-[-10%] w-[40vw] h-[40vw] bg-neutral-100 rounded-full blur-[120px] -z-10 opacity-60"></div>
-      <div className="fixed bottom-[-10%] left-[-10%] w-[40vw] h-[40vw] bg-neutral-50 rounded-full blur-[120px] -z-10 opacity-60"></div>
+      <div className={`fixed top-[-10%] right-[-10%] w-[40vw] h-[40vw] rounded-full blur-[120px] -z-10 opacity-60 ${dark ? "bg-zinc-800" : "bg-neutral-100"}`} />
+      <div className={`fixed bottom-[-10%] left-[-10%] w-[40vw] h-[40vw] rounded-full blur-[120px] -z-10 opacity-60 ${dark ? "bg-zinc-900" : "bg-neutral-50"}`} />
     </div>
   );
 };

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,14 +1,16 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useTheme } from '../context/ThemeContext';
+import ThemeToggle from '../components/ThemeToggle';
 
 const Dashboard = () => {
-  const [dark, setDark] = useState(false);
+  const { dark } = useTheme();
   const [percentage, setPercentage] = useState(0);
 
   useEffect(() => {
     const savedTasks = localStorage.getItem("tasks");
     let calcPercentage = 0;
-    
+
     if (savedTasks) {
       const tasks = JSON.parse(savedTasks);
       const totalTasks = tasks.length;
@@ -25,21 +27,19 @@ const Dashboard = () => {
     return () => clearTimeout(timer);
   }, []);
 
- const theme = {
-  light: {
-    wrapper: "bg-white text-black",
-    card: "bg-gray-50 border-gray-100 text-black hover:bg-black hover:text-white",
-    icon: "bg-white text-black group-hover:bg-white/10 group-hover:text-white",
-    thumb: "bg-black",
-  },
-  dark: {
-    wrapper: "bg-black text-white",
-    card: "bg-zinc-900 border-zinc-800 text-white hover:bg-white hover:text-black",
-    icon: "bg-black text-white group-hover:bg-black/10 group-hover:text-black",
-    thumb: "bg-gray-400",
-  }
-};
-const t = dark ? theme.dark : theme.light;
+  const theme = {
+    light: {
+      wrapper: "bg-white text-black",
+      card: "bg-gray-50 border-gray-100 text-black hover:bg-black hover:text-white",
+      icon: "bg-white text-black group-hover:bg-white/10 group-hover:text-white",
+    },
+    dark: {
+      wrapper: "bg-black text-white",
+      card: "bg-zinc-900 border-zinc-800 text-white hover:bg-white hover:text-black",
+      icon: "bg-black text-white group-hover:bg-black/10 group-hover:text-black",
+    }
+  };
+  const t = dark ? theme.dark : theme.light;
 
   const cards = [
     {
@@ -75,47 +75,44 @@ const t = dark ? theme.dark : theme.light;
   ];
 
   return (
-  <div className={`${t.wrapper} h-screen w-full font-sans overflow-hidden flex flex-col p-8 transition-colors duration-300 `}>
+    <div className={`${t.wrapper} h-screen w-full font-sans overflow-hidden flex flex-col p-8 transition-colors duration-300`}>
       <div className="max-w-6xl w-full mx-auto flex flex-col h-full">
         <header className="shrink-0 mb-12 flex justify-between items-end">
           <div>
             <h1 className="text-4xl font-black uppercase tracking-tighter mb-2">Dashboard</h1>
             <p className="text-gray-400 font-medium mb-6">Manage your engineering workflow</p>
-            
+
             <div className="w-full max-w-sm">
               <div className="text-xs font-black uppercase tracking-widest mb-2">
                 {percentage}% COMPLETE
               </div>
               <div className="h-2 w-full bg-gray-100 rounded-full overflow-hidden">
-                <div 
+                <div
                   className={`h-full transition-all duration-1000 ${dark ? 'bg-white' : 'bg-black'}`}
                   style={{ width: `${percentage}%` }}
-                ></div>
+                />
               </div>
             </div>
           </div>
 
-         <div className="flex items-center gap-4">
-       <label htmlFor="darkSwitch" className="relative inline-block w-11 h-6 cursor-pointer">
-        <input type="checkbox" id="darkSwitch" className="peer sr-only" checked={dark} onChange={() => setDark(!dark)} />
-
-        <span className={`absolute inset-0 rounded-full transition-colors duration-200 ${t.thumb}`} />
-        <span className="absolute top-1/2 left-0.5 -translate-y-1/2 w-5 h-5 bg-white rounded-full shadow-sm transition-transform duration-200 ease-in-out peer-checked:translate-x-full"></span>
-        </label>
-        <Link to="/" className="text-xs font-bold uppercase tracking-widest hover:underline pb-1"> Exit to Site </Link>
-         </div>
-          
+          <div className="flex items-center gap-4">
+            <ThemeToggle />
+            <Link to="/" className="text-xs font-bold uppercase tracking-widest hover:underline pb-1">
+              Exit to Site
+            </Link>
+          </div>
         </header>
 
         <div className="grow flex items-center justify-center">
           <div className="grid md:grid-cols-3 gap-8 w-full">
             {cards.map((card) => (
-              <Link 
-                key={card.title} 
+              <Link
+                key={card.title}
                 to={card.path}
-               className={`group relative p-8 border rounded-3xl transition-all duration-500 transform hover:-translate-y-2 flex flex-col justify-between h-[320px] ${t.card}`} >
+                className={`group relative p-8 border rounded-3xl transition-all duration-500 transform hover:-translate-y-2 flex flex-col justify-between h-[320px] ${t.card}`}
+              >
                 <div>
-                  <div className={`mb-8 p-3 w-fit  rounded-xl  transition-colors shadow-sm ${t.icon}`}>
+                  <div className={`mb-8 p-3 w-fit rounded-xl transition-colors shadow-sm ${t.icon}`}>
                     {card.icon}
                   </div>
                   <h2 className="text-xl font-black mb-3 uppercase tracking-tight">{card.title}</h2>
@@ -131,7 +128,6 @@ const t = dark ? theme.dark : theme.light;
           </div>
         </div>
 
-        {/* Decorative element */}
         <div className="shrink-0 mt-8 pt-8 border-t border-gray-50 opacity-10">
           <h2 className="text-[12vw] font-black tracking-tighter leading-none select-none text-center">FLOW</h2>
         </div>

--- a/src/pages/DeleteHistory.jsx
+++ b/src/pages/DeleteHistory.jsx
@@ -1,7 +1,11 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { toast } from "sonner";
+import { useTheme } from '../context/ThemeContext';
+import ThemeToggle from '../components/ThemeToggle';
+
 const DeleteHistory = () => {
+  const { dark } = useTheme();
   const [deletedTasks, setDeletedTasks] = useState(() => {
     const stored = localStorage.getItem('deleted_tasks');
     if (stored) {
@@ -15,57 +19,31 @@ const DeleteHistory = () => {
     return [];
   });
 
-  // Wipe out handler
   const handleWipeOut = () => {
     localStorage.removeItem('deleted_tasks');
     toast.success("All data wiped successfully.");
     setDeletedTasks([]);
   };
 
-const restoreTask = (id) => {
-  // Get deleted tasks
-  const deleted =
-    JSON.parse(localStorage.getItem("deleted_tasks")) || [];
+  const restoreTask = (id) => {
+    const deleted = JSON.parse(localStorage.getItem("deleted_tasks")) || [];
+    const tasks = JSON.parse(localStorage.getItem("tasks")) || [];
 
-  // Get active tasks
-  const tasks =
-    JSON.parse(localStorage.getItem("tasks")) || [];
+    const taskToRestore = deleted.find((task) => task.id === id);
+    if (!taskToRestore) return;
 
-  // Find the task to restore
-  const taskToRestore = deleted.find(
-    (task) => task.id === id
-  );
+    const updatedDeletedTasks = deleted.filter((task) => task.id !== id);
+    const updatedTasks = [...tasks, taskToRestore];
 
-  if (!taskToRestore) return;
+    localStorage.setItem("deleted_tasks", JSON.stringify(updatedDeletedTasks));
+    localStorage.setItem("tasks", JSON.stringify(updatedTasks));
 
-  // Remove from deleted tasks
-  const updatedDeletedTasks = deleted.filter(
-    (task) => task.id !== id
-  );
-
-  // Add back to active tasks
-  const updatedTasks = [...tasks, taskToRestore];
-
-  // Update localStorage
-  localStorage.setItem(
-    "deleted_tasks",
-    JSON.stringify(updatedDeletedTasks)
-  );
-
-  localStorage.setItem(
-    "tasks",
-    JSON.stringify(updatedTasks)
-  );
-
-  // Update state
-  setDeletedTasks(updatedDeletedTasks);
-
-  // Toast feedback
-  toast.success("Task restored to roadmap.");
-};
+    setDeletedTasks(updatedDeletedTasks);
+    toast.success("Task restored to roadmap.");
+  };
 
   return (
-    <div className="h-screen w-full bg-white text-black font-sans overflow-hidden flex flex-col p-8">
+    <div className={`h-screen w-full font-sans overflow-hidden flex flex-col p-8 transition-colors duration-300 ${dark ? "bg-black text-white" : "bg-white text-black"}`}>
       <div className="max-w-6xl w-full mx-auto flex flex-col h-full">
 
         {/* Header */}
@@ -79,12 +57,15 @@ const restoreTask = (id) => {
             </p>
           </div>
 
-          <Link
-            to="/dashboard"
-            className="text-xs font-bold uppercase tracking-widest hover:underline pb-1 flex items-center"
-          >
-            <span className="mr-2">←</span> Back to Dashboard
-          </Link>
+          <div className="flex items-center gap-4">
+            <ThemeToggle />
+            <Link
+              to="/dashboard"
+              className="text-xs font-bold uppercase tracking-widest hover:underline pb-1 flex items-center"
+            >
+              <span className="mr-2">←</span> Back to Dashboard
+            </Link>
+          </div>
         </header>
 
         {/* Main Content */}
@@ -93,42 +74,36 @@ const restoreTask = (id) => {
 
             {/* HISTORY LIST */}
             <div className="max-h-72 overflow-y-auto space-y-3 w-full pr-2">
-
               {deletedTasks.length === 0 ? (
-                <div className="text-center text-gray-400 font-medium py-10 border border-dashed border-gray-200 rounded-2xl">
+                <div className={`text-center font-medium py-10 border border-dashed rounded-2xl ${dark ? "text-gray-500 border-gray-700" : "text-gray-400 border-gray-200"}`}>
                   No deleted tasks found
                 </div>
               ) : (
                 deletedTasks.map((task) => (
                   <div
                     key={task.id}
-                    className="group border border-black/10 rounded-2xl px-5 py-4 flex items-center justify-between bg-white hover:bg-black hover:text-white transition-all duration-300 cursor-default"
+                    className={`group border rounded-2xl px-5 py-4 flex items-center justify-between transition-all duration-300 cursor-default ${
+                      dark
+                        ? "border-white/10 bg-zinc-900 hover:bg-white hover:text-black"
+                        : "border-black/10 bg-white hover:bg-black hover:text-white"
+                    }`}
                   >
-                    {/* Left Side */}
                     <div className="flex flex-col">
                       <span className="font-black uppercase tracking-wide text-sm">
                         {task.text}
                       </span>
-
                       <span className="text-xs text-gray-400 group-hover:text-gray-300 transition-colors duration-300 mt-1 tracking-wider uppercase">
                         Deleted Task
                       </span>
                     </div>
 
-                    {/* Right Side */}
                     <div className="text-right flex flex-col items-end gap-3">
-
                       <div>
                         <div className="text-xs font-medium text-gray-500 group-hover:text-gray-200 transition-colors duration-300">
-                          {task.deletedAt
-                            ? new Date(task.deletedAt).toLocaleDateString()
-                            : ""}
+                          {task.deletedAt ? new Date(task.deletedAt).toLocaleDateString() : ""}
                         </div>
-
                         <div className="text-[10px] uppercase tracking-[0.2em] text-gray-300 group-hover:text-gray-400 transition-colors duration-300 mt-1">
-                          {task.deletedAt
-                            ? new Date(task.deletedAt).toLocaleTimeString()
-                            : ""}
+                          {task.deletedAt ? new Date(task.deletedAt).toLocaleTimeString() : ""}
                         </div>
                       </div>
 
@@ -138,12 +113,10 @@ const restoreTask = (id) => {
                       >
                         Restore
                       </button>
-
                     </div>
                   </div>
                 ))
               )}
-
             </div>
 
             <div className="text-center space-y-6">
@@ -166,12 +139,11 @@ const restoreTask = (id) => {
             <div className="grid gap-4">
               <button
                 onClick={handleWipeOut}
-                className="group relative w-full py-6 bg-white border-2 border-black rounded-2xl font-black uppercase tracking-widest hover:bg-black hover:text-white transition-all duration-300 flex items-center justify-center overflow-hidden"
+                className={`group relative w-full py-6 border-2 rounded-2xl font-black uppercase tracking-widest transition-all duration-300 flex items-center justify-center overflow-hidden ${dark ? "bg-black border-white text-white" : "bg-white border-black text-black"} hover:text-white`}
               >
                 <span className="relative z-10">Clear History</span>
-                <div className="absolute inset-0 bg-red-600 translate-y-full group-hover:translate-y-0 transition-transform duration-300"></div>
+                <div className="absolute inset-0 bg-red-600 translate-y-full group-hover:translate-y-0 transition-transform duration-300" />
               </button>
- 
             </div>
           </div>
         </div>

--- a/src/pages/ListTasks.jsx
+++ b/src/pages/ListTasks.jsx
@@ -1,22 +1,24 @@
 import { useState } from "react";
 import { toast } from "sonner";
-import { Link} from "react-router-dom"
+import { Link } from "react-router-dom";
+import { useTheme } from "../context/ThemeContext";
+import ThemeToggle from "../components/ThemeToggle";
 
-const FILTERS = ["ALL", "ACTIVE", "COMPLETED"]; // ✅ Task 1 — filter options
+const FILTERS = ["ALL", "ACTIVE", "COMPLETED"];
 
 const ListTasks = () => {
+  const { dark } = useTheme();
   const [tasks, setTasks] = useState(() => {
     const savedTasks = localStorage.getItem("tasks");
     return savedTasks ? JSON.parse(savedTasks) : [];
   });
 
-  const [filter, setFilter] = useState("ALL"); // ✅ Task 1 — filter state
+  const [filter, setFilter] = useState("ALL");
 
-  // ✅ Task 1 — filter logic applied before rendering
   const filteredTasks = tasks.filter((task) => {
     if (filter === "ACTIVE") return !task.completed;
     if (filter === "COMPLETED") return task.completed;
-    return true; // "ALL"
+    return true;
   });
 
   const deleteTask = (id) => {
@@ -65,15 +67,18 @@ const ListTasks = () => {
   };
 
   return (
-    <div className="min-h-screen bg-[#FDFDFD] p-6 font-sans antialiased">
-      <div className="max-w-2xl mx-auto bg-white rounded-4xl shadow-lg p-8 border border-neutral-100">
-        <h1 className="text-3xl font-black text-black mb-8 text-center uppercase">
-          Task List
-        </h1>        
+    <div className={`min-h-screen p-6 font-sans antialiased transition-colors duration-300 ${dark ? "bg-zinc-950" : "bg-[#FDFDFD]"}`}>
+      <div className={`max-w-2xl mx-auto rounded-4xl shadow-lg p-8 border transition-colors duration-300 ${dark ? "bg-zinc-900 border-zinc-700" : "bg-white border-neutral-100"}`}>
+        <div className="flex justify-between items-center mb-8">
+          <h1 className={`text-3xl font-black uppercase ${dark ? "text-white" : "text-black"}`}>
+            Task List
+          </h1>
+          <ThemeToggle />
+        </div>
 
-        {/* ✅ Task 2 — Filter Navigation */}
+        {/* Filter Navigation */}
         <div className="flex justify-center mb-6">
-          <div className="flex gap-2 p-1 border border-neutral-200 rounded-full bg-neutral-50">
+          <div className={`flex gap-2 p-1 border rounded-full ${dark ? "border-zinc-700 bg-zinc-800" : "border-neutral-200 bg-neutral-50"}`}>
             {FILTERS.map((f) => (
               <button
                 key={f}
@@ -81,6 +86,8 @@ const ListTasks = () => {
                 className={`px-5 py-2 rounded-full text-xs font-black uppercase tracking-widest transition-all duration-200 cursor-pointer ${
                   filter === f
                     ? "bg-black text-white"
+                    : dark
+                    ? "bg-transparent text-neutral-400 hover:text-white border border-transparent hover:border-zinc-600"
                     : "bg-transparent text-neutral-400 hover:text-black border border-transparent hover:border-neutral-300"
                 }`}
               >
@@ -90,7 +97,6 @@ const ListTasks = () => {
           </div>
         </div>
 
-        {/* ✅ Task 3 — Updated task display using filteredTasks */}
         {filteredTasks.length === 0 ? (
           <p className="text-center text-neutral-400 font-medium py-8">
             {filter === "ACTIVE"
@@ -104,7 +110,7 @@ const ListTasks = () => {
             {filteredTasks.map((task) => (
               <li
                 key={task.id}
-                className="flex items-center justify-between bg-neutral-50 rounded-2xl p-4 shadow-sm"
+                className={`flex items-center justify-between rounded-2xl p-4 shadow-sm transition-colors duration-200 ${dark ? "bg-zinc-800" : "bg-neutral-50"}`}
               >
                 <div className="flex items-center gap-4">
                   <input
@@ -118,13 +124,13 @@ const ListTasks = () => {
                       className={`font-semibold text-lg ${
                         task.completed
                           ? "line-through text-neutral-400"
-                          : "text-black"
+                          : dark ? "text-white" : "text-black"
                       }`}
                     >
                       {task.text}
                     </span>
 
-                    <span className="text-[11px] font-black uppercase px-2 py-1 rounded-full bg-neutral-100 text-neutral-700">
+                    <span className={`text-[11px] font-black uppercase px-2 py-1 rounded-full ${dark ? "bg-zinc-700 text-neutral-300" : "bg-neutral-100 text-neutral-700"}`}>
                       {task.category ?? "TASK"}
                     </span>
                   </div>
@@ -132,7 +138,7 @@ const ListTasks = () => {
 
                 <button
                   onClick={() => deleteTask(task.id)}
-                  className="bg-black text-white px-4 py-2 rounded-xl hover:bg-neutral-800 transition-all duration-300"
+                  className={`px-4 py-2 rounded-xl transition-all duration-300 font-bold text-sm ${dark ? "bg-white text-black hover:bg-gray-100" : "bg-black text-white hover:bg-neutral-800"}`}
                 >
                   Delete
                 </button>
@@ -140,9 +146,10 @@ const ListTasks = () => {
             ))}
           </ul>
         )}
+
         <Link
           to="/dashboard"
-          className="mt-12 text-neutral-400 hover:text-black font-bold text-sm uppercase tracking-widest transition-all duration-300 flex items-center space-x-2"
+          className={`mt-12 font-bold text-sm uppercase tracking-widest transition-all duration-300 flex items-center space-x-2 ${dark ? "text-neutral-400 hover:text-white" : "text-neutral-400 hover:text-black"}`}
         >
           <span>←</span>
           <span>Back to Dashboard</span>


### PR DESCRIPTION
## Summary

- Moved theme state out of `Dashboard.jsx` into a global `ThemeContext` (Context API + `useTheme` hook)
- Theme preference is persisted to `localStorage` and survives page refresh
- The `dark` class is toggled on `<html>` via `useEffect`, so there is no flash of incorrect theme on navigation
- Created a reusable `ThemeToggle` component using `react-icons` (`FaMoon` / `FaSun`) with bold uppercase labels
- Added the toggle to the header of all four pages: **Dashboard**, **AddTasks**, **ListTasks**, **DeleteHistory**
- Applied consistent monochrome dark/light styling across every page

## Files changed

| File | Change |
|------|--------|
| `src/context/ThemeContext.jsx` | New — global theme provider + `useTheme` hook |
| `src/components/ThemeToggle.jsx` | New — reusable toggle button with react-icons |
| `src/App.jsx` | Wrapped with `<ThemeProvider>` |
| `src/pages/Dashboard.jsx` | Replaced local `dark` state with `useTheme()` |
| `src/pages/AddTasks.jsx` | Added dark mode classes + `<ThemeToggle />` |
| `src/pages/ListTasks.jsx` | Added dark mode classes + `<ThemeToggle />` |
| `src/pages/DeleteHistory.jsx` | Added dark mode classes + `<ThemeToggle />` |

## Demo

[▶️ Watch demo video on Google Drive](https://drive.google.com/file/d/13We3waXXvqpX-MnPnkTw-Cb5v4gHhi43/view)


> Screen recording showing theme switching across all pages included below.

## Test plan

- [x] Toggle switches theme on Dashboard
- [x] Navigate to AddTasks / ListTasks / DeleteHistory — theme stays consistent
- [x] Refresh the page — theme preference is restored from localStorage
- [x] No flash of incorrect theme on load or navigation
- [x] All pages show the toggle button with icon + label

Closes #39