### PR TITLE
feat: implement inline task editing

### DIFF
--- a/src/pages/ListTasks.jsx
+++ b/src/pages/ListTasks.jsx
@@ -11,6 +11,8 @@ const ListTasks = () => {
   });
 
   const [filter, setFilter] = useState("ALL"); // ✅ Task 1 — filter state
+  const [editingId, setEditingId] = useState(null);
+  const [editingText, setEditingText] = useState("");
 
   // ✅ Task 1 — filter logic applied before rendering
   const filteredTasks = tasks.filter((task) => {
@@ -18,6 +20,33 @@ const ListTasks = () => {
     if (filter === "COMPLETED") return task.completed;
     return true; // "ALL"
   });
+
+  const startEditing = (task) => {
+    setEditingId(task.id);
+    setEditingText(task.text);
+  };
+
+  const saveEdit = (id) => {
+    const trimmed = editingText.trim();
+    if (!trimmed) {
+      setEditingId(null);
+      return;
+    }
+    const updatedTasks = tasks.map((task) =>
+      task.id === id ? { ...task, text: trimmed } : task
+    );
+    setTasks(updatedTasks);
+    localStorage.setItem("tasks", JSON.stringify(updatedTasks));
+    setEditingId(null);
+    toast.success("Task updated.", {
+      style: { background: "#000000", color: "#ffffff" },
+    });
+  };
+
+  const handleEditKeyDown = (e, id) => {
+    if (e.key === "Enter") saveEdit(id);
+    if (e.key === "Escape") setEditingId(null);
+  };
 
   const deleteTask = (id) => {
     let deletedTasks = localStorage.getItem("deleted_tasks");
@@ -69,7 +98,7 @@ const ListTasks = () => {
       <div className="max-w-2xl mx-auto bg-white rounded-4xl shadow-lg p-8 border border-neutral-100">
         <h1 className="text-3xl font-black text-black mb-8 text-center uppercase">
           Task List
-        </h1>        
+        </h1>
 
         {/* ✅ Task 2 — Filter Navigation */}
         <div className="flex justify-center mb-6">
@@ -106,36 +135,58 @@ const ListTasks = () => {
                 key={task.id}
                 className="flex items-center justify-between bg-neutral-50 rounded-2xl p-4 shadow-sm"
               >
-                <div className="flex items-center gap-4">
+                <div className="flex items-center gap-4 flex-1 min-w-0">
                   <input
                     type="checkbox"
                     checked={task.completed}
                     onChange={() => toggleComplete(task.id)}
-                    className="w-5 h-5 accent-black cursor-pointer"
+                    className="w-5 h-5 accent-black cursor-pointer shrink-0"
                   />
-                  <div className="flex items-center gap-3">
-                    <span
-                      className={`font-semibold text-lg ${
-                        task.completed
-                          ? "line-through text-neutral-400"
-                          : "text-black"
-                      }`}
-                    >
-                      {task.text}
-                    </span>
+                  <div className="flex items-center gap-3 flex-1 min-w-0">
+                    {editingId === task.id ? (
+                      <input
+                        type="text"
+                        value={editingText}
+                        autoFocus
+                        onChange={(e) => setEditingText(e.target.value)}
+                        onBlur={() => saveEdit(task.id)}
+                        onKeyDown={(e) => handleEditKeyDown(e, task.id)}
+                        className="flex-1 min-w-0 bg-transparent border-b-2 border-black outline-none font-bold text-lg text-black uppercase tracking-wide pb-0.5 transition-all duration-200"
+                      />
+                    ) : (
+                      <span
+                        className={`font-semibold text-lg truncate ${
+                          task.completed
+                            ? "line-through text-neutral-400"
+                            : "text-black"
+                        }`}
+                      >
+                        {task.text}
+                      </span>
+                    )}
 
-                    <span className="text-[11px] font-black uppercase px-2 py-1 rounded-full bg-neutral-100 text-neutral-700">
+                    <span className="text-[11px] font-black uppercase px-2 py-1 rounded-full bg-neutral-100 text-neutral-700 shrink-0">
                       {task.category ?? "TASK"}
                     </span>
                   </div>
                 </div>
 
-                <button
-                  onClick={() => deleteTask(task.id)}
-                  className="bg-black text-white px-4 py-2 rounded-xl hover:bg-neutral-800 transition-all duration-300"
-                >
-                  Delete
-                </button>
+                <div className="flex items-center gap-2 ml-3 shrink-0">
+                  {!task.completed && editingId !== task.id && (
+                    <button
+                      onClick={() => startEditing(task)}
+                      className="px-4 py-2 rounded-xl border border-black text-black font-bold text-sm hover:bg-black hover:text-white transition-all duration-300"
+                    >
+                      Edit
+                    </button>
+                  )}
+                  <button
+                    onClick={() => deleteTask(task.id)}
+                    className="bg-black text-white px-4 py-2 rounded-xl hover:bg-neutral-800 transition-all duration-300 font-bold text-sm"
+                  >
+                    Delete
+                  </button>
+                </div>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary

- Added `editingId` state to track which task is currently being edited
- Added `editingText` state to hold the live input value during editing
- Conditionally renders an `<input />` in place of the task text span when `task.id === editingId`
- Saves on **Enter** key press or **onBlur** (input loses focus), cancels on **Escape**
- Updated task text is synced to both component state and `localStorage`
- Edit button is only shown for incomplete tasks and hidden while that task is in edit mode
- Toast feedback shown on successful save using the existing `sonner` library

## Files changed

| File | Change |
|------|--------|
| `src/pages/ListTasks.jsx` | Added inline editing state and conditional input rendering |

## Test plan

- [x] Click Edit on a task — input appears with current text pre-filled and autofocused
- [x] Press Enter — saves the new text and returns to display mode
- [x] Click outside (blur) — saves the new text
- [x] Press Escape — cancels editing without saving
- [x] Empty input on save — discards edit, no toast shown
- [x] Completed tasks do not show the Edit button
- [x] Updated text persists after page refresh (localStorage sync)

Closes #41