### PR TITLE
feat: implement task priority levels

### DIFF
--- a/src/pages/AddTasks.jsx
+++ b/src/pages/AddTasks.jsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 const AddTasks = () => {
   const [task, setTask] = useState("");
   const [category, setCategory] = useState("FEATURE");
+  const [priority, setPriority] = useState("MEDIUM");
   const [tasks, setTasks] = useState(() => {
     const savedTasks = localStorage.getItem("tasks");
     return savedTasks ? JSON.parse(savedTasks) : [];
@@ -23,6 +24,7 @@ const AddTasks = () => {
       id: Date.now(),
       text: task,
       category,
+      priority,
       completed: false,
     };
 
@@ -33,6 +35,7 @@ const AddTasks = () => {
     });
 
     setTask("");
+    setPriority("MEDIUM");
   };
 
   return (
@@ -105,6 +108,31 @@ const AddTasks = () => {
                   }`}
                 >
                   {opt}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="text-left">
+            <label className="block text-[11px] font-black text-neutral-400 uppercase tracking-[0.25em] mb-3 ml-6">
+              Priority
+            </label>
+
+            <div className="flex items-center gap-3 ml-6">
+              {[
+                { value: "HIGH", color: "bg-red-500 text-white border-red-500", inactive: "bg-red-500/10 text-red-500 border-red-200 hover:bg-red-500/20" },
+                { value: "MEDIUM", color: "bg-yellow-500 text-white border-yellow-500", inactive: "bg-yellow-500/10 text-yellow-600 border-yellow-200 hover:bg-yellow-500/20" },
+                { value: "LOW", color: "bg-blue-500 text-white border-blue-500", inactive: "bg-blue-500/10 text-blue-500 border-blue-200 hover:bg-blue-500/20" },
+              ].map(({ value, color, inactive }) => (
+                <button
+                  type="button"
+                  key={value}
+                  onClick={() => setPriority(value)}
+                  className={`px-3 py-1 rounded-full text-xs font-black uppercase tracking-widest transition-all duration-200 cursor-pointer border ${
+                    priority === value ? color : inactive
+                  }`}
+                >
+                  {value}
                 </button>
               ))}
             </div>

--- a/src/pages/ListTasks.jsx
+++ b/src/pages/ListTasks.jsx
@@ -173,6 +173,20 @@ const ListTasks = () => {
                         <span className={`text-[11px] font-black uppercase px-2 py-1 rounded-full ${dark ? "bg-zinc-700 text-neutral-300" : "bg-neutral-100 text-neutral-700"}`}>
                           {task.category ?? "TASK"}
                         </span>
+
+                        {task.priority && (
+                          <span
+                            className={`text-[11px] font-black uppercase px-2 py-1 rounded-full shrink-0 ${
+                              task.priority === "HIGH"
+                                ? "bg-red-500/10 text-red-500"
+                                : task.priority === "MEDIUM"
+                                ? "bg-yellow-500/10 text-yellow-600"
+                                : "bg-blue-500/10 text-blue-500"
+                            }`}
+                          >
+                            {task.priority}
+                          </span>
+                        )}
                       </div>
                     )}
                   </div>

--- a/src/pages/ListTasks.jsx
+++ b/src/pages/ListTasks.jsx
@@ -168,6 +168,20 @@ const ListTasks = () => {
                     <span className="text-[11px] font-black uppercase px-2 py-1 rounded-full bg-neutral-100 text-neutral-700 shrink-0">
                       {task.category ?? "TASK"}
                     </span>
+
+                    {task.priority && (
+                      <span
+                        className={`text-[11px] font-black uppercase px-2 py-1 rounded-full shrink-0 ${
+                          task.priority === "HIGH"
+                            ? "bg-red-500/10 text-red-500"
+                            : task.priority === "MEDIUM"
+                            ? "bg-yellow-500/10 text-yellow-600"
+                            : "bg-blue-500/10 text-blue-500"
+                        }`}
+                      >
+                        {task.priority}
+                      </span>
+                    )}
                   </div>
                 </div>
 


### PR DESCRIPTION
## Summary

- Added HIGH / MEDIUM / LOW priority selector to the Add Task form using a button-group matching the existing category style
- Priority defaults to MEDIUM and resets after task creation
- Priority field is saved to localStorage alongside the task object
- Color-coded pill badges displayed in the task list: red for HIGH, yellow for MEDIUM, blue for LOW
- Badges only render when a priority field exists, keeping backward compatibility with older tasks

## Test plan

- [ ] Open Add Task page — Priority selector shows with MEDIUM pre-selected
- [ ] Switch priority to HIGH/LOW — button highlights with the correct color
- [ ] Create a task — verify it appears in the task list with the correct priority badge
- [ ] Reload the page — priority badge persists from localStorage
- [ ] Existing tasks without a priority field show no badge (no crash)

Closes #46