### PR TITLE
feat: implement undo delete toast action

### DIFF
--- a/src/pages/ListTasks.jsx
+++ b/src/pages/ListTasks.jsx
@@ -57,6 +57,27 @@ const ListTasks = () => {
     if (e.key === "Escape") setEditingId(null);
   };
 
+  const restoreDeletedTask = (taskToRestore) => {
+    let deletedTasks = localStorage.getItem("deleted_tasks");
+    if (deletedTasks) {
+      deletedTasks = JSON.parse(deletedTasks).filter(
+        (t) => t.id !== taskToRestore.id
+      );
+      localStorage.setItem("deleted_tasks", JSON.stringify(deletedTasks));
+    }
+
+    setTasks((prevTasks) => {
+      if (prevTasks.some((t) => t.id === taskToRestore.id)) return prevTasks;
+      const updatedTasks = [...prevTasks, taskToRestore];
+      localStorage.setItem("tasks", JSON.stringify(updatedTasks));
+      return updatedTasks;
+    });
+
+    toast.success("Action undone.", {
+      style: { background: "#000000", color: "#ffffff" },
+    });
+  };
+
   const deleteTask = (id) => {
     let deletedTasks = localStorage.getItem("deleted_tasks");
 
@@ -80,6 +101,10 @@ const ListTasks = () => {
     localStorage.setItem("tasks", JSON.stringify(updatedTasks));
     toast.warning("Task permanently removed.", {
       style: { background: "#000000", color: "#ffffff" },
+      action: {
+        label: "Undo",
+        onClick: () => restoreDeletedTask(deletedTask),
+      },
     });
   };
 


### PR DESCRIPTION
## Summary

Implemented an interactive "Undo Delete" toast action for deleted tasks to improve user experience and recovery flow.

### Changes
- Updated the delete task toast to include an `Undo` action
- Added task restore functionality
- Restored deleted tasks back into the active task list
- Removed restored tasks from `deleted_tasks`
- Synchronized all updates with localStorage
- Added success feedback after restoration
- Preserved existing UI and project theme consistency

Closes #56 

---

### Checklist
- [x] Feature tested locally
- [x] localStorage synchronization verified
- [x] Existing functionality preserved
- [x] UI kept minimal and consistent
- [x] No unnecessary dependencies added