### PR TITLE
fix: standardize snippet import schema

### DIFF
--- a/src/pages/SnippetVault/snippetvault/DataCenter.jsx
+++ b/src/pages/SnippetVault/snippetvault/DataCenter.jsx
@@ -82,7 +82,7 @@ const DataCenter = () => {
           (s) =>
             typeof s.id !== "undefined" &&
             typeof s.title === "string" &&
-            typeof s.code === "string" &&
+            (typeof s.code === "string" || typeof s.cmd === "string") &&
             ["GIT", "DOCKER", "NPM", "OTHER"].includes(s.category)
         );
 
@@ -93,18 +93,22 @@ const DataCenter = () => {
           return;
         }
 
-        localStorage.setItem("dev_snippets", JSON.stringify(parsed.snippets));
+        const normalized = parsed.snippets.map((s) =>
+          s.code !== undefined ? s : { ...s, code: s.cmd, cmd: undefined }
+        );
+
+        localStorage.setItem("dev_snippets", JSON.stringify(normalized));
 
         setSnippetStats({
-          total: parsed.snippets.length,
-          git: parsed.snippets.filter((s) => s.category === "GIT").length,
-          docker: parsed.snippets.filter((s) => s.category === "DOCKER").length,
-          npm: parsed.snippets.filter((s) => s.category === "NPM").length,
-          other: parsed.snippets.filter((s) => s.category === "OTHER").length,
+          total: normalized.length,
+          git: normalized.filter((s) => s.category === "GIT").length,
+          docker: normalized.filter((s) => s.category === "DOCKER").length,
+          npm: normalized.filter((s) => s.category === "NPM").length,
+          other: normalized.filter((s) => s.category === "OTHER").length,
         });
 
         toast.success(
-          `Import completed! Loaded ${parsed.snippets.length} snippets.`,
+          `Import completed! Loaded ${normalized.length} snippets.`,
           { style: { background: "#000000", color: "#ffffff" } }
         );
       } catch {


### PR DESCRIPTION
Fixes the schema mismatch in `DataCenter.jsx` import validation that caused valid snippet backups to fail or render incorrectly.

- Updated validation to accept both `code` and `cmd` property names for backward compatibility
- Added normalization pass that converts legacy `cmd` snippets to the canonical `code` schema before writing to localStorage

## Screenshots
<img width="1025" height="887" alt="Screenshot 2026-06-04 180940" src="https://github.com/user-attachments/assets/aa6c3b25-f028-4dfd-a86a-7244dc86e528" />

https://github.com/user-attachments/assets/912b08b7-a390-4fc1-994b-a282b52b7006


Closes #123 