### PR TITLE
fix: implement snippet edit flow and copy improvements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -52,6 +52,7 @@ function AppInner({ toggleHUD, hudVisible }) {
         <Route path="/snippetvault" element={<SnippetVault />} />
         <Route path="/snippetvault/add" element={<AddSnippet />} />
         <Route path="/snippetvault/list" element={<ListSnippets />} />
+        <Route path="/snippetvault/edit/:snippetid" element={<AddSnippet />} />
         <Route path="/snippetvault/delete-history" element={<DeleteHistorySnippet />} />
         <Route path="/snippetvault/data-center" element={<DataCenterSnippet />} />
       </Routes>

--- a/src/pages/SnippetVault/snippetvault/AddSnippet.jsx
+++ b/src/pages/SnippetVault/snippetvault/AddSnippet.jsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import { useTheme } from "../../../context/ThemeContext";
 import ThemeToggle from "../../../components/ThemeToggle";
@@ -10,6 +10,44 @@ const AddSnippet = () => {
   const [title, setTitle] = useState("");
   const [code, setCode] = useState("");
   const [category, setCategory] = useState("GIT");
+
+  const { snippetid } = useParams();
+  const isEdit = Boolean(snippetid);
+
+  useEffect(() => {
+    if (isEdit) {
+      const getSnippetById = (id) => {
+        const raw = localStorage.getItem("dev_snippets");
+        if (!raw) {
+          toast.error("Snippet not found.", {
+            style: { background: "#000000", color: "#ffffff" },
+          });
+          setTitle("");
+          setCode("");
+          setCategory("GIT");
+          return;
+        }
+        const existing = JSON.parse(raw);
+        const snippet = existing.find((data) => data.id === id);
+        if (!snippet) {
+          toast.error("Snippet not found.", {
+            style: { background: "#000000", color: "#ffffff" },
+          });
+          setTitle("");
+          setCode("");
+          setCategory("GIT");
+          return;
+        }
+
+        setTitle(snippet.title);
+        setCode(snippet.code);
+        setCategory(snippet.category);
+      };
+
+      getSnippetById(snippetid);
+      document.title = "Edit Snippet — Dev Snippet Vault";
+    }
+  }, [snippetid, isEdit]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -28,23 +66,45 @@ const AddSnippet = () => {
     }
 
     // 2. Build snippet object
-    const newSnippet = {
-      id: crypto.randomUUID ? crypto.randomUUID() : Date.now().toString(36) + Math.random().toString(36).slice(2),
-      title: trimmedTitle,
-      code: trimmedCode,
-      category,
-      createdAt: new Date().toISOString()
-    };
+    let snippet = {};
+    if (isEdit) {
+      snippet = {
+        title: trimmedTitle,
+        code: trimmedCode,
+        category,
+      };
+    } else {
+      snippet = {
+        id: crypto.randomUUID ? crypto.randomUUID() : Date.now().toString(36) + Math.random().toString(36).slice(2),
+        title: trimmedTitle,
+        code: trimmedCode,
+        category,
+        createdAt: new Date().toISOString()
+      };
+    }
 
     // 3. LocalStorage Persistence
     const raw = localStorage.getItem("dev_snippets");
     const existing = raw ? JSON.parse(raw) : [];
-    existing.push(newSnippet);
-    localStorage.setItem("dev_snippets", JSON.stringify(existing));
+    if (isEdit) {
+      const updateSnippets = existing.map((existingSnippet) => {
+        if (existingSnippet.id === snippetid) {
+          return {
+            id: snippetid,
+            ...snippet,
+            createdAt: existingSnippet.createdAt,
+          };
+        }
+        return existingSnippet;
+      });
+      localStorage.setItem("dev_snippets", JSON.stringify(updateSnippets));
+    } else {
+      existing.push(snippet);
+      localStorage.setItem("dev_snippets", JSON.stringify(existing));
+    }
 
     // 4. Toast Notification (Success)
-    toast.success("Snippet successfully secured in vault!");
-
+    toast.success(isEdit ? "Snippet successfully updated!" : "Snippet successfully secured in vault!");
     // 5. Reset Form
     setTitle("");
     setCode("");
@@ -138,7 +198,7 @@ const AddSnippet = () => {
                 dark ? "text-white" : "text-black"
               }`}
             >
-              Add New Snippet
+              { isEdit ? "Edit Snippet" : "Add New Snippet" }
             </h1>
             <p className="text-xs sm:text-sm text-neutral-400 mt-1">
               Store a new template block in your developer vault

--- a/src/pages/SnippetVault/snippetvault/ListSnippets.jsx
+++ b/src/pages/SnippetVault/snippetvault/ListSnippets.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useTheme } from "../../../context/ThemeContext";
 import ThemeToggle from "../../../components/ThemeToggle";
+import { toast } from "sonner";
 
 const ListSnippets = () => {
   const { dark } = useTheme();
@@ -44,8 +45,14 @@ const ListSnippets = () => {
   const handleCopy = async (code) => {
     try {
       await navigator.clipboard.writeText(code);
+      toast.success("Snippet copied successfully!", {
+      style: { background: "#000000", color: "#ffffff" },
+    });
     } catch (error) {
       console.error("Copy failed:", error);
+      toast.error("Snippet copy failed.", {
+      style: { background: "#000000", color: "#ffffff" },
+    });
     }
   };
 

--- a/src/pages/SnippetVault/snippetvault/ListSnippets.jsx
+++ b/src/pages/SnippetVault/snippetvault/ListSnippets.jsx
@@ -27,12 +27,12 @@ const ListSnippets = () => {
 
   const filteredSnippets = snippets.filter((snippet) => {
     const title = snippet?.title || "";
-    const cmd = snippet?.cmd || "";
+    const code = snippet?.code || "";
     const category = snippet?.category || "";
 
     const matchesSearch =
       title.toLowerCase().includes((searchQuery || "").toLowerCase()) ||
-      cmd.toLowerCase().includes((searchQuery || "").toLowerCase());
+      code.toLowerCase().includes((searchQuery || "").toLowerCase());
 
     const matchesCategory =
       selectedCategory === "ALL" ||
@@ -41,9 +41,9 @@ const ListSnippets = () => {
     return matchesSearch && matchesCategory;
   });
 
-  const handleCopy = async (cmd) => {
+  const handleCopy = async (code) => {
     try {
-      await navigator.clipboard.writeText(cmd);
+      await navigator.clipboard.writeText(code);
     } catch (error) {
       console.error("Copy failed:", error);
     }
@@ -158,13 +158,13 @@ const ListSnippets = () => {
                       : "bg-neutral-100 text-neutral-800"
                     }`}
                 >
-                  {sn.cmd}
+                  {sn.code}
                 </pre>
 
                 {/* Actions */}
                 <div className="flex flex-col sm:flex-row gap-2 sm:justify-end">
                   <button
-                    onClick={() => handleCopy(sn.cmd)}
+                    onClick={() => handleCopy(sn.code)}
                     className={`px-4 py-2 rounded-xl border font-bold text-sm transition-all duration-300 active:scale-95 ${dark
                         ? "border-white text-white hover:bg-white hover:text-black"
                         : "border-black text-black hover:bg-black hover:text-white"


### PR DESCRIPTION
## 📝 Description
This pull request improves the Snippet Vault experience by fixing snippet search/copy behavior, adding toast feedback for copy actions, and introducing snippet editing support.

### Changes included
- Fixed snippet list logic to use the `code` field instead of `cmd`
- Added success and error toast notifications when copying snippets
- Added edit support for existing snippets
- Added routing for `/snippetvault/edit/:snippetid`
- Reused the snippet form for both creating and editing entries while preserving existing metadata

## 🔗 Related Issue
Closes #131 

## 🎯 Type of Change
- [x] `fix`: Bug fix
- [x] `feat`: New feature
- [ ] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist
- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [x] Added screenshots (if UI was changed) 📸
- [x] Tested locally on the latest version 🧪

## 📸 Screenshots (if applicable)
### Before
#### Copy button
<img width="320" height="240" alt="image" src="https://github.com/user-attachments/assets/c32e70a1-0131-44a8-a248-15d658f2c104" />

#### Snippet edit
<img width="320" height="240" alt="image" src="https://github.com/user-attachments/assets/6962a632-663b-48ff-ab4e-3475c9afe5cb" />


### After
#### Copy button
https://github.com/user-attachments/assets/1867bc0c-a208-478c-955f-b7daf2272cdf


#### Snippet edit
https://github.com/user-attachments/assets/49b3465e-c226-4745-96f9-33a9b78251f1


