### PR TITLE
feat: implement snippet vault delete history system

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,6 +51,7 @@ function AppInner({ toggleHUD, hudVisible }) {
         <Route path="/taskmanage/data-center" element={<DataCenter />} />
         <Route path="/snippetvault" element={<SnippetVault />} />
         <Route path="/snippetvault/add" element={<AddSnippet />} />
+        <Route path="/snippetvault/edit/:id" element={<AddSnippet />} />
         <Route path="/snippetvault/list" element={<ListSnippets />} />
         <Route path="/snippetvault/delete-history" element={<DeleteHistorySnippet />} />
         <Route path="/snippetvault/data-center" element={<DataCenterSnippet />} />

--- a/src/pages/SnippetVault/snippetvault/DeleteHistory.jsx
+++ b/src/pages/SnippetVault/snippetvault/DeleteHistory.jsx
@@ -1,35 +1,283 @@
-import { Link } from "react-router-dom";
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { useTheme } from "../../../context/ThemeContext";
+import ThemeToggle from "../../../components/ThemeToggle";
 
 const DeleteHistory = () => {
-  // TODO: Fetch deleted snippets history from localStorage
-  const deletedList = [
-    { id: 3, title: "Docker Nuke", cmd: "docker system prune -a --volumes -f", category: "DOCKER", deletedAt: new Date().toISOString() }
-  ];
+  const { dark } = useTheme();
+  const navigate = useNavigate();
 
-  const handleRestore = (sn) => {
-    // TODO: Implement restore logic
+  const [deletedSnippets, setDeletedSnippets] = useState(() => {
+    const stored = localStorage.getItem("deleted_snippets");
+    if (stored) {
+      try {
+        return JSON.parse(stored);
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  });
+
+  const handleRestore = (snippet) => {
+    const deleted = JSON.parse(localStorage.getItem("deleted_snippets") || "[]");
+    const active = JSON.parse(localStorage.getItem("dev_snippets") || "[]");
+
+    const { deletedAt, ...snippetToRestore } = snippet;
+
+    const updatedDeleted = deleted.filter((s) => s.id !== snippet.id);
+    const updatedActive = [...active, snippetToRestore];
+
+    localStorage.setItem("deleted_snippets", JSON.stringify(updatedDeleted));
+    localStorage.setItem("dev_snippets", JSON.stringify(updatedActive));
+    setDeletedSnippets(updatedDeleted);
+
+    toast("Snippet restored to vault", {
+      description: "Moved back to active snippets",
+      action: {
+        label: "View Snippets",
+        onClick: () => navigate("/snippetvault/list"),
+      },
+      cancel: {
+        label: "Undo",
+        onClick: () => {
+          const current = JSON.parse(localStorage.getItem("dev_snippets") || "[]");
+          const currentDeleted = JSON.parse(localStorage.getItem("deleted_snippets") || "[]");
+          localStorage.setItem(
+            "dev_snippets",
+            JSON.stringify(current.filter((s) => s.id !== snippet.id))
+          );
+          localStorage.setItem(
+            "deleted_snippets",
+            JSON.stringify([...currentDeleted, snippet])
+          );
+          setDeletedSnippets((prev) => [...prev, snippet]);
+        },
+      },
+    });
   };
 
   const handlePurge = (id) => {
-    // TODO: Implement permanent purge logic
+    toast("Permanently delete this snippet?", {
+      description: "This action cannot be undone.",
+      action: {
+        label: "Yes, Purge",
+        onClick: () => {
+          const updated = deletedSnippets.filter((s) => s.id !== id);
+          localStorage.setItem("deleted_snippets", JSON.stringify(updated));
+          setDeletedSnippets(updated);
+          toast.success("Snippet permanently purged.", {
+            style: { background: "#000000", color: "#ffffff" },
+          });
+        },
+      },
+      cancel: {
+        label: "Cancel",
+        onClick: () => {
+          toast("Purge cancelled.", {
+            style: { background: "#000000", color: "#ffffff" },
+          });
+        },
+      },
+    });
+  };
+
+  const handleClearHistory = () => {
+    toast("Clear all deleted snippet history?", {
+      description: "This action cannot be undone.",
+      action: {
+        label: "Yes, Clear All",
+        onClick: () => {
+          localStorage.removeItem("deleted_snippets");
+          setDeletedSnippets([]);
+          toast.success("All history cleared.", {
+            style: { background: "#000000", color: "#ffffff" },
+          });
+        },
+      },
+      cancel: {
+        label: "Cancel",
+        onClick: () => {
+          toast("Cancelled.", {
+            style: { background: "#000000", color: "#ffffff" },
+          });
+        },
+      },
+    });
   };
 
   return (
-    <div style={{ padding: "20px", fontFamily: "sans-serif" }}>
-      <h1>Deleted Snippets Log</h1>
-      <ul>
-        {deletedList.map((sn) => (
-          <li key={sn.id} style={{ marginBottom: "15px" }}>
-            <h3>{sn.title}</h3>
-            <pre style={{ background: "#eee", padding: "10px" }}>{sn.cmd}</pre>
-            <p>Deleted at: {new Date(sn.deletedAt).toLocaleString()}</p>
-            <button onClick={() => handleRestore(sn)}>Restore</button>
-            <button onClick={() => handlePurge(sn.id)} style={{ marginLeft: "10px", color: "red" }}>Purge</button>
-          </li>
-        ))}
-      </ul>
-      <div style={{ marginTop: "20px" }}>
-        <Link to="/snippetvault">Back to Workspace</Link>
+    <div
+      className={`min-h-screen md:h-screen w-full font-sans overflow-y-auto md:overflow-hidden flex flex-col p-4 md:p-8 transition-colors duration-300 ${
+        dark ? "bg-black text-white" : "bg-white text-black"
+      }`}
+    >
+      <title>System Logs & Purge History — Snippet Vault</title>
+      <meta
+        name="description"
+        content="View deleted snippets history, restore snippets, or permanently clear logs."
+      />
+
+      <div className="max-w-6xl w-full mx-auto flex flex-col h-full">
+        <header className="shrink-0 mb-12 flex flex-col md:flex-row justify-between items-start md:items-end gap-6">
+          <div className="animate-in fade-in slide-in-from-left duration-700">
+            <h1 className="text-4xl font-black uppercase tracking-tighter mb-2">
+              Snippet Logs
+            </h1>
+            <p className="text-gray-400 font-medium">
+              Restore deleted snippets or purge records permanently
+            </p>
+          </div>
+
+          <div className="flex items-center gap-4">
+            <ThemeToggle />
+            <Link
+              to="/snippetvault"
+              className="text-xs font-bold uppercase tracking-widest hover:underline pb-1 flex items-center"
+            >
+              <span className="mr-2">←</span> Back to Workspace
+            </Link>
+          </div>
+        </header>
+
+        <div className="grow flex items-center justify-center">
+          <div className="max-w-xl w-full space-y-12 animate-in fade-in zoom-in duration-1000">
+            <div className="max-h-72 overflow-y-auto space-y-3 w-full pr-2">
+              {deletedSnippets.length === 0 ? (
+                <div
+                  className={`text-center font-medium py-10 border border-dashed rounded-2xl ${
+                    dark
+                      ? "text-gray-500 border-gray-700"
+                      : "text-gray-400 border-gray-200"
+                  }`}
+                >
+                  No deleted snippets found
+                </div>
+              ) : (
+                deletedSnippets.map((sn) => (
+                  <div
+                    key={sn.id}
+                    className={`group border rounded-2xl px-5 py-4 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 transition-all duration-300 cursor-default ${
+                      dark
+                        ? "border-white/10 bg-zinc-900 hover:bg-white hover:text-black"
+                        : "border-black/10 bg-white hover:bg-black hover:text-white"
+                    }`}
+                  >
+                    <div className="flex flex-col min-w-0 flex-1">
+                      <span className="font-black uppercase tracking-wide text-sm truncate">
+                        {sn.title}
+                      </span>
+                      <span
+                        className={`text-xs font-mono truncate mt-1 ${
+                          dark ? "text-zinc-400" : "text-neutral-500"
+                        } group-hover:text-gray-300 transition-colors`}
+                      >
+                        {sn.code || sn.cmd}
+                      </span>
+                      <span className="text-[10px] uppercase tracking-[0.2em] text-gray-400 group-hover:text-gray-400 transition-colors duration-300 mt-1">
+                        {sn.category}
+                      </span>
+                    </div>
+
+                    <div className="flex flex-col items-start sm:items-end gap-2 shrink-0">
+                      <div>
+                        <div className="text-xs font-medium text-gray-500 group-hover:text-gray-200 transition-colors duration-300">
+                          {sn.deletedAt
+                            ? new Date(sn.deletedAt).toLocaleDateString()
+                            : ""}
+                        </div>
+                        <div className="text-[10px] uppercase tracking-[0.2em] text-gray-400 group-hover:text-gray-400 transition-colors duration-300 mt-0.5">
+                          {sn.deletedAt
+                            ? new Date(sn.deletedAt).toLocaleTimeString()
+                            : ""}
+                        </div>
+                      </div>
+
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => handleRestore(sn)}
+                          className="border border-black/20 px-3 py-1 rounded-xl text-[10px] font-black uppercase tracking-widest hover:bg-black hover:text-white transition-all duration-300"
+                        >
+                          Restore
+                        </button>
+                        <button
+                          onClick={() => handlePurge(sn.id)}
+                          className="border border-red-400/40 text-red-500 px-3 py-1 rounded-xl text-[10px] font-black uppercase tracking-widest hover:bg-red-600 hover:text-white hover:border-red-600 transition-all duration-300"
+                        >
+                          Purge
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+
+            <div className="text-center space-y-6">
+              <div className="inline-flex items-center justify-center w-20 h-20 bg-red-50 text-red-600 rounded-3xl mb-4">
+                <svg
+                  className="w-10 h-10"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                  />
+                </svg>
+              </div>
+              <h2 className="text-3xl font-black uppercase tracking-tight">
+                Danger Zone
+              </h2>
+              <p className="text-gray-500 font-medium leading-relaxed">
+                Clearing history will permanently remove all deleted snippet
+                records. Individual snippets can be restored or purged above.
+              </p>
+            </div>
+
+            <div className="grid gap-4">
+              <button
+                onClick={handleClearHistory}
+                className={`group relative w-full py-6 border-2 rounded-2xl font-black uppercase tracking-widest transition-all duration-300 flex items-center justify-center overflow-hidden ${
+                  dark
+                    ? "bg-black border-white text-white"
+                    : "bg-white border-black text-black"
+                } hover:text-white`}
+              >
+                <span className="relative z-10">Clear All History</span>
+                <div className="absolute inset-0 bg-red-600 translate-y-full group-hover:translate-y-0 transition-transform duration-300" />
+              </button>
+
+              <div className="flex flex-col sm:flex-row gap-4 justify-between items-center mt-6 border-t border-neutral-100 dark:border-zinc-800 pt-6">
+                <Link
+                  to="/snippetvault/list"
+                  className={`inline-flex items-center gap-2 text-xs sm:text-sm font-black uppercase tracking-widest transition-all duration-300 ${
+                    dark
+                      ? "text-neutral-400 hover:text-white"
+                      : "text-neutral-500 hover:text-black"
+                  }`}
+                >
+                  Snippet List
+                </Link>
+                <Link
+                  to="/snippetvault/data-center"
+                  className={`inline-flex items-center gap-2 text-xs sm:text-sm font-black uppercase tracking-widest transition-all duration-300 ${
+                    dark
+                      ? "text-neutral-400 hover:text-white"
+                      : "text-neutral-500 hover:text-black"
+                  }`}
+                >
+                  <span>Data Center</span>
+                  <span>→</span>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/SnippetVault/snippetvault/ListSnippets.jsx
+++ b/src/pages/SnippetVault/snippetvault/ListSnippets.jsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
 import { useTheme } from "../../../context/ThemeContext";
 import ThemeToggle from "../../../components/ThemeToggle";
 
 const ListSnippets = () => {
   const { dark } = useTheme();
+  const navigate = useNavigate();
 
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("ALL");
@@ -50,13 +52,66 @@ const ListSnippets = () => {
   };
 
   const handleDelete = (id) => {
+    const snippetToDelete = snippets.find((s) => s.id === id);
+    if (!snippetToDelete) return;
+
+    const rawDeleted = localStorage.getItem("deleted_snippets");
+    const deletedList = rawDeleted ? JSON.parse(rawDeleted) : [];
+    const snippetWithTimestamp = {
+      ...snippetToDelete,
+      deletedAt: new Date().toISOString(),
+    };
+    localStorage.setItem(
+      "deleted_snippets",
+      JSON.stringify([...deletedList, snippetWithTimestamp])
+    );
+
     const updated = snippets.filter((s) => s.id !== id);
     setSnippets(updated);
-    try {
-      localStorage.setItem("dev_snippets", JSON.stringify(updated));
-    } catch (err) {
-      console.error("Failed to update localStorage:", err);
-    }
+    localStorage.setItem("dev_snippets", JSON.stringify(updated));
+
+    toast.warning("Snippet removed from vault.", {
+      style: { background: "#000000", color: "#ffffff" },
+      action: {
+        label: "Undo",
+        onClick: () => {
+          const current = JSON.parse(localStorage.getItem("dev_snippets") || "[]");
+          const currentDeleted = JSON.parse(localStorage.getItem("deleted_snippets") || "[]");
+          localStorage.setItem(
+            "dev_snippets",
+            JSON.stringify([...current, snippetToDelete])
+          );
+          localStorage.setItem(
+            "deleted_snippets",
+            JSON.stringify(currentDeleted.filter((s) => s.id !== id))
+          );
+          setSnippets((prev) => [...prev, snippetToDelete]);
+          toast.success("Snippet restored.", {
+            style: { background: "#000000", color: "#ffffff" },
+          });
+        },
+      },
+      duration: 4000,
+    });
+
+    setTimeout(() => {
+      toast.info("View in delete history to restore later.", {
+        style: { background: "#000000", color: "#ffffff" },
+        action: {
+          label: "View Logs",
+          onClick: () => navigate("/snippetvault/delete-history"),
+        },
+        actionButtonStyle: {
+          border: "1px solid #ffffff",
+          borderRadius: "8px",
+          backgroundColor: "transparent",
+          color: "#ffffff",
+          padding: "6px 16px",
+          cursor: "pointer",
+        },
+        duration: 5000,
+      });
+    }, 4100);
   };
 
   return (
@@ -158,13 +213,13 @@ const ListSnippets = () => {
                       : "bg-neutral-100 text-neutral-800"
                     }`}
                 >
-                  {sn.cmd}
+                  {sn.code || sn.cmd}
                 </pre>
 
                 {/* Actions */}
                 <div className="flex flex-col sm:flex-row gap-2 sm:justify-end">
                   <button
-                    onClick={() => handleCopy(sn.cmd)}
+                    onClick={() => handleCopy(sn.code || sn.cmd)}
                     className={`px-4 py-2 rounded-xl border font-bold text-sm transition-all duration-300 active:scale-95 ${dark
                         ? "border-white text-white hover:bg-white hover:text-black"
                         : "border-black text-black hover:bg-black hover:text-white"


### PR DESCRIPTION
## 📝 Description
Implements the Snippet Vault Delete History system as described in issue #132,
bringing it to the same standard as the existing Task Management Delete History.

### Changes made:

**`src/pages/SnippetVault/snippetvault/ListSnippets.jsx`**
- Updated `handleDelete` to save deleted snippets into `deleted_snippets`
  localStorage key with a `deletedAt` timestamp before removing from `dev_snippets`
- Added Sonner toast on delete with Undo support
- Fixed pre-existing bug: `sn.cmd` → `sn.code || sn.cmd` for backward compatibility

**`src/pages/SnippetVault/snippetvault/DeleteHistory.jsx`**
- Complete rewrite replacing the static placeholder
- Loads deleted snippets from `deleted_snippets` localStorage
- Restore: moves snippet back to `dev_snippets`, removes from `deleted_snippets`
- Purge: permanently removes a single snippet with Sonner confirmation dialog
- Clear History: removes all deleted snippets with Sonner confirmation dialog
- Undo support on restore toast
- Integrated `useTheme` and `<ThemeToggle />` for dark/light mode
- Added React 19 document metadata (`<title>` and `<meta>`)
- Responsive layout matching Task Management styling patterns

**`src/App.jsx`**
- Added missing `/snippetvault/edit/:id` route pointing to `<AddSnippet />`

## 🔗 Related Issue
Closes #132 

## 🎯 Type of Change
- [ ] `fix`: Bug fix
- [x] `feat`: New feature
- [ ] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist
- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [x] Added screenshots (if UI was changed) 📸
- [x] Tested locally on the latest version 🧪

## 📸 Screenshots (if applicable)
| Before | After |
| --- | --- |
| Static placeholder with hardcoded data | Fully functional delete history |

Deleted Snippets go to LocalStorage deleted_snippets:
<img width="1877" height="886" alt="deleted_snippets-entry" src="https://github.com/user-attachments/assets/24664254-1019-4ee1-9bf3-b0e579751395" />

Deleted Snippets History:
<img width="1880" height="896" alt="delete-history" src="https://github.com/user-attachments/assets/c07f809c-95ce-4e77-95eb-0dc9f4f28edc" />

Restoring Snippet
<img width="1880" height="896" alt="restore-snippet" src="https://github.com/user-attachments/assets/c01572ef-dfa7-4b03-92db-48462958c1fe" />

Purge Deleted Snippet (Confirmation Toast):
<img width="1880" height="896" alt="purge-deleted-snippet" src="https://github.com/user-attachments/assets/38607ad9-8d69-4a97-9dce-0ce76bf64887" />

Clear All History (Confirmation Toast):
<img width="1880" height="896" alt="clear-all-confirmation" src="https://github.com/user-attachments/assets/ac3600fb-f4cf-496a-88d5-4b33c9afacee" />

Deleted Snippets History (dark):
<img width="1880" height="896" alt="delete-history-dark" src="https://github.com/user-attachments/assets/4d343790-90bb-4fa1-af57-f37450d843e7" />
