### PR TITLE
 ui: redesign AddResource page

### DIFF
--- a/src/pages/ResourceHub/resourcehub/AddResource.jsx
+++ b/src/pages/ResourceHub/resourcehub/AddResource.jsx
@@ -1,12 +1,204 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
+import { useTheme } from "../../../context/ThemeContext";
+import ThemeToggle from "../../../components/ThemeToggle";
+
+const categories = ["FIGMA", "API", "DOCS", "STAGING"];
 
 const AddResource = () => {
+  const { dark } = useTheme();
+  const [resourceName, setResourceName] = useState("");
+  const [resourceUrl, setResourceUrl] = useState("");
+  const [description, setDescription] = useState("");
+  const [category, setCategory] = useState("FIGMA");
+
   return (
-    <div style={{ padding: "40px", fontFamily: "sans-serif" }}>
-      <h1>Add Resource</h1>
-      <p>This is a placeholder page to add new resources to the database.</p>
-      <div style={{ marginTop: "20px" }}>
-        <Link to="/resourcehub">← Back to Workspace</Link>
+    <div
+      className={`min-h-screen px-4 sm:px-6 py-8 flex items-center justify-center transition-colors duration-300 overflow-hidden relative ${
+        dark ? "bg-zinc-950" : "bg-[#F7F7F7]"
+      }`}
+    >
+      <div
+        className={`absolute top-[-10%] right-[-10%] w-[300px] sm:w-[500px] h-[300px] sm:h-[500px] rounded-full blur-[100px] opacity-30 transition-colors duration-500 ${
+          dark ? "bg-zinc-800" : "bg-neutral-200"
+        }`}
+      />
+      <div
+        className={`absolute bottom-[-10%] left-[-10%] w-[300px] sm:w-[500px] h-[300px] sm:h-[500px] rounded-full blur-[100px] opacity-30 transition-colors duration-500 ${
+          dark ? "bg-zinc-900" : "bg-neutral-100"
+        }`}
+      />
+
+      <div
+        className={`relative z-10 w-[85%] max-w-none rounded-[32px] border shadow-2xl overflow-hidden transition-all duration-300 ${
+          dark ? "bg-zinc-900 border-zinc-800" : "bg-white border-neutral-200"
+        }`}
+      >
+        <div
+          className={`h-2 w-full transition-colors duration-500 ${
+            dark ? "bg-white" : "bg-black"
+          }`}
+        />
+
+        <div className="flex items-start justify-between px-6 sm:px-10 pt-8 sm:pt-10 gap-4">
+          <div>
+            <h1
+              className={`text-2xl sm:text-3xl font-black uppercase tracking-tight transition-colors duration-300 ${
+                dark ? "text-white" : "text-black"
+              }`}
+            >
+              Add New Resource
+            </h1>
+            <p className="text-xs sm:text-sm text-neutral-400 mt-1">
+              Save project links, docs, designs, and staging references
+            </p>
+          </div>
+          <ThemeToggle />
+        </div>
+
+        <div className="p-6 sm:p-10">
+          <form className="space-y-6 flex flex-col justify-between">
+            <div className="space-y-5">
+              <div className="group flex flex-col space-y-2">
+                <label
+                  className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
+                    dark
+                      ? "text-zinc-400 group-focus-within:text-white"
+                      : "text-neutral-500 group-focus-within:text-black"
+                  }`}
+                >
+                  Resource Name
+                </label>
+                <input
+                  type="text"
+                  value={resourceName}
+                  onChange={(e) => setResourceName(e.target.value)}
+                  placeholder="e.g. Product Design System"
+                  className={`w-full px-4 py-3 rounded-2xl border text-sm font-semibold outline-none transition-all duration-300 ${
+                    dark
+                      ? "bg-zinc-950 border-zinc-800 text-white placeholder-zinc-700 focus:border-white focus:ring-1 focus:ring-white"
+                      : "bg-neutral-50 border-neutral-300 text-black placeholder-neutral-400 focus:border-black focus:ring-1 focus:ring-black"
+                  }`}
+                />
+              </div>
+
+              <div className="group flex flex-col space-y-2">
+                <label
+                  className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
+                    dark
+                      ? "text-zinc-400 group-focus-within:text-white"
+                      : "text-neutral-500 group-focus-within:text-black"
+                  }`}
+                >
+                  Resource URL
+                </label>
+                <input
+                  type="url"
+                  value={resourceUrl}
+                  onChange={(e) => setResourceUrl(e.target.value)}
+                  placeholder="https://example.com/resource"
+                  className={`w-full px-4 py-3 rounded-2xl border text-sm font-semibold outline-none transition-all duration-300 ${
+                    dark
+                      ? "bg-zinc-950 border-zinc-800 text-white placeholder-zinc-700 focus:border-white focus:ring-1 focus:ring-white"
+                      : "bg-neutral-50 border-neutral-300 text-black placeholder-neutral-400 focus:border-black focus:ring-1 focus:ring-black"
+                  }`}
+                />
+              </div>
+
+              <div className="group flex flex-col space-y-2">
+                <label
+                  className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
+                    dark
+                      ? "text-zinc-400 group-focus-within:text-white"
+                      : "text-neutral-500 group-focus-within:text-black"
+                  }`}
+                >
+                  Category Tags
+                </label>
+                <div className="flex flex-wrap gap-3">
+                  {categories.map((item) => (
+                    <button
+                      key={item}
+                      type="button"
+                      onClick={() => setCategory(item)}
+                      className={`px-2 py-1.5 sm:px-4 sm:py-2 rounded-full text-[10px] sm:text-xs font-black uppercase tracking-widest border transition-all duration-300 ${
+                        category === item
+                          ? dark
+                            ? "bg-white text-black border-white"
+                            : "bg-black text-white border-black"
+                          : dark
+                            ? "bg-zinc-800 border-zinc-700 text-neutral-300 hover:border-white hover:text-white"
+                            : "bg-neutral-100 border-neutral-200 text-neutral-600 hover:border-black hover:text-black"
+                      }`}
+                    >
+                      {item}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="group flex flex-col space-y-2">
+                <label
+                  className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
+                    dark
+                      ? "text-zinc-400 group-focus-within:text-white"
+                      : "text-neutral-500 group-focus-within:text-black"
+                  }`}
+                >
+                  Description
+                </label>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Add a short note about when to use this resource."
+                  rows={5}
+                  className={`w-full px-4 py-3 rounded-2xl border text-sm outline-none transition-all duration-300 resize-none ${
+                    dark
+                      ? "bg-zinc-950 border-zinc-800 text-white placeholder-zinc-700 focus:border-white focus:ring-1 focus:ring-white"
+                      : "bg-neutral-50 border-neutral-300 text-black placeholder-neutral-400 focus:border-black focus:ring-1 focus:ring-black"
+                  }`}
+                />
+              </div>
+            </div>
+
+            <div className="pt-6 grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <Link
+                to="/resourcehub"
+                className={`w-full py-4 rounded-2xl text-xs font-black uppercase tracking-widest border transition-all duration-300 transform active:scale-95 text-center ${
+                  dark
+                    ? "bg-zinc-900 border-zinc-700 text-neutral-300 hover:border-white hover:text-white"
+                    : "bg-white border-neutral-300 text-neutral-600 hover:border-black hover:text-black"
+                }`}
+              >
+                Cancel
+              </Link>
+              <button
+                type="button"
+                className={`w-full py-4 rounded-2xl text-xs font-black uppercase tracking-widest border transition-all duration-300 transform active:scale-95 ${
+                  dark
+                    ? "bg-white border-white text-black hover:bg-neutral-200"
+                    : "bg-black border-black text-white hover:bg-neutral-800"
+                }`}
+              >
+                Submit Resource
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <div className="px-6 sm:px-10 pb-8 flex items-center border-t border-neutral-100 dark:border-zinc-800 pt-6">
+          <Link
+            to="/resourcehub"
+            className={`inline-flex items-center gap-2 text-xs sm:text-sm font-black uppercase tracking-widest transition-all duration-300 ${
+              dark
+                ? "text-neutral-400 hover:text-white"
+                : "text-neutral-500 hover:text-black"
+            }`}
+          >
+            <span>&larr;</span>
+            <span>Back to Workspace</span>
+          </Link>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 📝 Description
Redesigned the Add Resource page from a placeholder into a responsive, theme-aware form UI.  
The page now includes inputs for resource name, URL, category tags, and description, with monochrome styling for both light and dark modes.

## 🔗 Related Issue
Closes #

## 🎯 Type of Change
- [ ] `fix`: Bug fix
- [ ] `feat`: New feature
- [x] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist
- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [x] Added screenshots (if UI was changed) 📸
- [x] Tested locally on the latest version 🧪

## 📸 Screenshots
| Before | After |
| 
<img width="1910" height="988" alt="before" src="https://github.com/user-attachments/assets/37558e5f-706a-46c8-8bc8-cd6b24bfbdfb" />
 | 
<img width="1914" height="907" alt="after (dark mode)" src="https://github.com/user-attachments/assets/190ea5ca-9695-43f2-b3fe-1ad265857402" />
<img width="1910" height="989" alt="after(light mode)" src="https://github.com/user-attachments/assets/fda09d03-8a5a-4159-a056-89e890a7d31d" />
 |