### PR TITLE
fix(snippets): replace snippetid with id to match route parameter

### DIFF
--- a/src/pages/SnippetVault/snippetvault/AddSnippet.jsx
+++ b/src/pages/SnippetVault/snippetvault/AddSnippet.jsx
@@ -11,8 +11,8 @@ const AddSnippet = () => {
   const [code, setCode] = useState("");
   const [category, setCategory] = useState("GIT");
 
-  const { snippetid } = useParams();
-  const isEdit = Boolean(snippetid);
+  const { id } = useParams();
+  const isEdit = Boolean(id);
 
   useEffect(() => {
     if (isEdit) {
@@ -44,10 +44,10 @@ const AddSnippet = () => {
         setCategory(snippet.category);
       };
 
-      getSnippetById(snippetid);
+      getSnippetById(id);
       document.title = "Edit Snippet — Dev Snippet Vault";
     }
-  }, [snippetid, isEdit]);
+  }, [id, isEdit]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -88,9 +88,9 @@ const AddSnippet = () => {
     const existing = raw ? JSON.parse(raw) : [];
     if (isEdit) {
       const updateSnippets = existing.map((existingSnippet) => {
-        if (existingSnippet.id === snippetid) {
+        if (existingSnippet.id === id) {
           return {
-            id: snippetid,
+            id,
             ...snippet,
             createdAt: existingSnippet.createdAt,
           };


### PR DESCRIPTION
## 📝 Description
Replaced snippetid with id in `src/pages/SnippetVault/snippetvault/AddSnippet.jsx` to match the URL parameter.

## 🔗 Related Issue
Closes #143 

## 🎯 Type of Change
- [x] `fix`: Bug fix
- [ ] `feat`: New feature
- [ ] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist
- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [ ] Added screenshots (if UI was changed) 📸
- [x] Tested locally on the latest version 🧪

## 📸 Screenshots (if applicable)
| Before | After |
| --- | --- |
| | |
