### PR TITLE
feat: implement json formatter functionality

### DIFF
--- a/src/pages/DevUtilities/devutilities/JsonFormatter.jsx
+++ b/src/pages/DevUtilities/devutilities/JsonFormatter.jsx
@@ -1,11 +1,54 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
+import { toast } from "sonner";
 import { useTheme } from "../../../context/ThemeContext";
 import ThemeToggle from "../../../components/ThemeToggle";
 
-const formatCategories = ["Format", "Minify", "Clear"]; 
-
 const JsonFormatter = () => {
   const { dark } = useTheme();
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState("");
+
+  const handleFormat = () => {
+    try {
+      if (!input.trim()) return;
+      const parsed = JSON.parse(input);
+      setOutput(JSON.stringify(parsed, null, 2));
+    } catch (error) {
+      toast.error("Invalid JSON format");
+    }
+  };
+
+  const handleMinify = () => {
+    try {
+      if (!input.trim()) return;
+      const parsed = JSON.parse(input);
+      setOutput(JSON.stringify(parsed));
+    } catch (error) {
+      toast.error("Invalid JSON format");
+    }
+  };
+
+  const handleClear = () => {
+    setInput("");
+    setOutput("");
+  };
+
+  const handleCopy = async () => {
+    try {
+      if (!output) return;
+      await navigator.clipboard.writeText(output);
+      toast.success("Copied to clipboard");
+    } catch (error) {
+      toast.error("Failed to copy");
+    }
+  };
+
+  const buttons = [
+    { label: "Format", onClick: handleFormat },
+    { label: "Minify", onClick: handleMinify },
+    { label: "Clear", onClick: handleClear },
+  ];
   return (
     <div
       className={`min-h-screen px-4 sm:px-6 py-8 flex items-center justify-center transition-colors duration-300 overflow-hidden relative ${
@@ -66,6 +109,8 @@ const JsonFormatter = () => {
                 Input
               </label>
               <textarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
                 placeholder='{"title":"devtask"}'
                 className={`md:h-full h-40 px-4 py-3 rounded-2xl border text-sm outline-none transition-all duration-300 resize-none ${
                   dark
@@ -74,9 +119,10 @@ const JsonFormatter = () => {
                 }`}
               />
               <div className="grid grid-cols-3 gap-3">
-                {formatCategories.map((item) => (
+                {buttons.map((btn) => (
                   <button
-                    key={item}
+                    key={btn.label}
+                    onClick={btn.onClick}
                     type="button"
                     className={`w-full px-4 py-2 rounded-xl border font-bold text-sm text-center transition-all duration-300 active:scale-95 ${
                       dark
@@ -84,7 +130,7 @@ const JsonFormatter = () => {
                         : "border-black text-black hover:bg-black hover:text-white"
                     }`}
                   >
-                    {item}
+                    {btn.label}
                   </button>
                 ))}
               </div>
@@ -101,6 +147,7 @@ const JsonFormatter = () => {
                 Output
               </label>
               <textarea
+                value={output}
                 readOnly
                 className={`md:h-full h-40 px-4 py-3 rounded-2xl border text-sm outline-none transition-all duration-300 resize-none ${
                   dark
@@ -110,6 +157,7 @@ const JsonFormatter = () => {
               />
               <div className={"flex justify-end"}>
                 <button
+                  onClick={handleCopy}
                   type="button"
                   className={`w-40 px-4 py-2 rounded-xl border font-bold text-sm text-center transition-all duration-300 active:scale-95
                     ${dark


### PR DESCRIPTION
## 📝 Description
This PR implements the core functionality for the JSON Formatter utility page. 

It adds React state (`useState`) to manage the input and output fields and wire up the action buttons:
- **Format**: Parses input JSON and formats it with a 2-space indentation.
- **Minify**: Minifies JSON by stripping unnecessary whitespace.
- **Clear**: Resets both input and output fields.
- **Copy**: Copies the output to the clipboard using the Clipboard API.
- **Validation/Feedback**: Integrates `sonner` toast notifications to show errors for invalid JSON formatting, as well as success/error states when copying to the clipboard.


## 🎯 Type of Change
- [ ] `fix`: Bug fix
- [x] `feat`: New feature
- [ ] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist
- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [ ] Added screenshots (if UI was changed) 📸
- [x] Tested locally on the latest version 🧪

## 📸 Screenshots (if applicable)
| Before | After |
<img width="1710" height="1107" alt="Screenshot 2026-06-09 at 6 02 43 PM" src="https://github.com/user-attachments/assets/60c8662f-2525-4a11-aaea-40fa2187923e" />
<img width="1710" height="1107" alt="Screenshot 2026-06-09 at 6 03 15 PM" src="https://github.com/user-attachments/assets/3a6e42ff-969c-4fb2-99a6-691cefc5189e" />
<img width="1710" height="1107" alt="Screenshot 2026-06-09 at 6 03 51 PM" src="https://github.com/user-attachments/assets/8d8d962d-b041-41e1-bfd9-41fc726122b6" />
<img width="1710" height="1107" alt="Screenshot 2026-06-09 at 6 04 04 PM" src="https://github.com/user-attachments/assets/923c6f9c-c2ad-4b0d-986e-92047d5b3f72" />

| *(UI layout was unchanged, but interactivity and toasts were added. Please add your own screen recording or screenshots here if required by the maintainer)* | |
