### PR TITLE
feat: implement add resource page functionality

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -79,6 +79,7 @@ function AppInner({ toggleHUD, hudVisible }) {
         {/* Resource Hub */}
         <Route path="/resourcehub" element={<ResourceHub />} />
         <Route path="/resourcehub/add" element={<AddResource />} />
+        <Route path="/resourcehub/edit/:id" element={<AddResource />} />
         <Route path="/resourcehub/list" element={<ListResources />} />
         <Route path="/resourcehub/delete-history" element={<DeleteHistoryResource />} />
         <Route path="/resourcehub/data-center" element={<DataCenterResource />} />

--- a/src/pages/ResourceHub/resourcehub/AddResource.jsx
+++ b/src/pages/ResourceHub/resourcehub/AddResource.jsx
@@ -87,6 +87,9 @@ const AddResource = () => {
         dark ? "bg-zinc-950" : "bg-[#F7F7F7]"
       }`}
     >
+      <title>Add Resource | DevTasks</title>
+      <meta name="description" content="Create and manage development resources." />
+      
       <div
         className={`absolute top-[-10%] right-[-10%] w-[300px] sm:w-[500px] h-[300px] sm:h-[500px] rounded-full blur-[100px] opacity-30 transition-colors duration-500 ${
           dark ? "bg-zinc-800" : "bg-neutral-200"

--- a/src/pages/ResourceHub/resourcehub/AddResource.jsx
+++ b/src/pages/ResourceHub/resourcehub/AddResource.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { useTheme } from "../../../context/ThemeContext";
 import ThemeToggle from "../../../components/ThemeToggle";
 import { toast } from "sonner";
@@ -9,34 +9,78 @@ const categories = ["GENERAL", "LOCALHOST", "STAGING", "FIGMA", "DOCUMENTATION"]
 const AddResource = () => {
   const navigate = useNavigate();
   const { dark } = useTheme();
-  const [resourceName, setResourceName] = useState("");
-  const [resourceUrl, setResourceUrl] = useState("");
-  const [description, setDescription] = useState("");
-  const [category, setCategory] = useState("GENERAL");
-
+  const [resource, setResource] = useState({
+    id: null,
+    title: "",
+    url: "",
+    description: "",
+    category: "GENERAL",
+    createdAt: null
+  });
   const [resources, setResources] = useState(() => {
     const existingResources = localStorage.getItem("dev_resources");
     return existingResources ? JSON.parse(existingResources) : [];
   });
+  const { id } = useParams();
+  const isEdit = Boolean(id);
 
   useEffect(() => {
     localStorage.setItem("dev_resources", JSON.stringify(resources));
   }, [resources]);
 
+  useEffect(() => {
+    if (isEdit) {
+      if (resources.length === 0) {
+        toast.error("Resource not found.");
+        navigate("/resourcehub/add");
+        return;
+      }
+      const getResourceById = (id) => {
+        const existingResource = resources.find((item) => item.id === id);
+        if (!existingResource) {
+          toast.error("Resource not found.");
+          navigate("/resourcehub/add");
+          return;
+        }
+        setResource(existingResource);
+      };
+
+      getResourceById(id);
+      document.title = "Edit Resource | DevTasks"
+    } 
+  }, [id, isEdit, resources, navigate]);
+
+  const addResource = (newResource) => {
+    setResources([
+      ...resources,
+      {
+        id: crypto.randomUUID(),
+        ...newResource,
+        createdAt: new Date().toISOString(),
+      }
+    ]);
+  };
+
+  const updateResource = (resource) => {
+    setResources(resources.map((existingResource) => (
+      existingResource.id === resource.id ? {...resource} : existingResource
+    )));
+  };
+
+
   const handleSubmit = (event) => {
     event.preventDefault()
-    console.log(event);
     const validationErrors = [];
-    const trimedResourceName = resourceName.trim();
-    const trimedResourceUrl = resourceUrl.trim();
+    const trimedResourceTitle = resource.title.trim();
+    const trimedResourceUrl = resource.url.trim();
 
-    if (!trimedResourceName) {
+    if (!trimedResourceTitle) {
       validationErrors.push("・Resource name");
     }
     if (!trimedResourceUrl) {
       validationErrors.push("・Resource url");
     }
-    if (!category) {
+    if (!resource.category) {
       validationErrors.push("・Category tag");
     }
 
@@ -45,8 +89,8 @@ const AddResource = () => {
         { 
           description: (
             <div>
-              {validationErrors.map((message) => (
-                <div>{message}</div>
+              {validationErrors.map((message, index) => (
+                <div key={index}>{message}</div>
               ))}
             </div>
           )
@@ -55,18 +99,24 @@ const AddResource = () => {
       return;
     }
 
-    const newResource = {
-      id: crypto.randomUUID(),
-      title: trimedResourceName,
+    const resourceValue = {
+      title: trimedResourceTitle,
       url: trimedResourceUrl,
-      category,
-      description,
-      createdAt: new Date().toISOString()
+      category: resource.category,
+      description: resource.description
+    };
+
+    if (isEdit) {
+      updateResource({
+        id: resource.id,
+        ...resourceValue,
+        createdAt: resource.createdAt
+      });
+    } else {
+      addResource(resourceValue);
     }
 
-    setResources([...resources, newResource]); 
-
-    toast.success("Resource successfully added.",
+    toast.success(isEdit ? "Resource successfully updated." : "Resource successfully added.",
       {
         action: {
           label: "view list",
@@ -75,10 +125,14 @@ const AddResource = () => {
       }
     );
 
-    setResourceName("");
-    setResourceUrl("");
-    setCategory("GENERAL");
-    setDescription("");
+    setResource({
+      id: null,
+      title: "",
+      url: "",
+      description: "",
+      category: "GENERAL",
+      createdAt: null
+    });
   };
 
   return (
@@ -119,7 +173,7 @@ const AddResource = () => {
                 dark ? "text-white" : "text-black"
               }`}
             >
-              Add New Resource
+              {isEdit ? "Edit Resource" : "Add New Resource"}
             </h1>
             <p className="text-xs sm:text-sm text-neutral-400 mt-1">
               Save project links, docs, designs, and staging references
@@ -128,8 +182,8 @@ const AddResource = () => {
           <ThemeToggle />
         </div>
 
-        <div className="p-6 sm:p-10 flex flex-col md:flex-row gap-4p-6 sm:p-10 grid grid-cols-1 lg:grid-cols-12 gap-8 sm:gap-10">
-          <form className="space-y-6 flex flex-col justify-between lg:col-span-7">
+        <div className="p-6 sm:p-10 grid grid-cols-1 lg:grid-cols-12 gap-8 sm:gap-10">
+          <form onSubmit={handleSubmit} className="space-y-6 flex flex-col justify-between lg:col-span-7">
             <div className="space-y-5">
               <div className="group flex flex-col space-y-2">
                 <label
@@ -143,8 +197,8 @@ const AddResource = () => {
                 </label>
                 <input
                   type="text"
-                  value={resourceName}
-                  onChange={(e) => setResourceName(e.target.value)}
+                  value={resource.title}
+                  onChange={(e) => setResource({...resource, title: e.target.value})}
                   placeholder="e.g. Product Design System"
                   className={`w-full px-4 py-3 rounded-2xl border text-sm font-semibold outline-none transition-all duration-300 ${
                     dark
@@ -166,8 +220,8 @@ const AddResource = () => {
                 </label>
                 <input
                   type="url"
-                  value={resourceUrl}
-                  onChange={(e) => setResourceUrl(e.target.value)}
+                  value={resource.url}
+                  onChange={(e) => setResource({...resource, url: e.target.value})}
                   placeholder="https://example.com/resource"
                   className={`w-full px-4 py-3 rounded-2xl border text-sm font-semibold outline-none transition-all duration-300 ${
                     dark
@@ -192,9 +246,9 @@ const AddResource = () => {
                     <button
                       key={item}
                       type="button"
-                      onClick={() => setCategory(item)}
+                      onClick={() => setResource({...resource, category: item})}
                       className={`px-2 py-1.5 sm:px-4 sm:py-2 rounded-full text-[10px] sm:text-xs font-black uppercase tracking-widest border transition-all duration-300 ${
-                        category === item
+                        resource.category === item
                           ? dark
                             ? "bg-white text-black border-white"
                             : "bg-black text-white border-black"
@@ -220,8 +274,8 @@ const AddResource = () => {
                   Description
                 </label>
                 <textarea
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
+                  value={resource.description}
+                  onChange={(e) => setResource({...resource, description: e.target.value})}
                   placeholder="Add a short note about when to use this resource."
                   rows={5}
                   className={`w-full px-4 py-3 rounded-2xl border text-sm outline-none transition-all duration-300 resize-none ${
@@ -246,14 +300,13 @@ const AddResource = () => {
               </Link>
               <button
                 type="submit"
-                onClick={handleSubmit}
                 className={`w-full py-4 rounded-2xl text-xs font-black uppercase tracking-widest border transition-all duration-300 transform active:scale-95 ${
                   dark
                     ? "bg-white border-white text-black hover:bg-neutral-200"
                     : "bg-black border-black text-white hover:bg-neutral-800"
                 }`}
               >
-                Submit Resource
+                {isEdit ? "Update Resource" : "Submit Resource"}
               </button>
             </div>
           </form>
@@ -284,7 +337,7 @@ const AddResource = () => {
                       className={`flex items-center gap-2 px-3 py-1.5 rounded-full border text-[10px] font-black uppercase tracking-wider transition-all duration-300 ${dark ? "bg-white text-black" : "bg-black text-white"}
                         `}
                     >
-                      <span>{category}</span>
+                      <span>{resource.category}</span>
                     </div>
 
                     <div className="flex items-center gap-1.5">
@@ -296,14 +349,14 @@ const AddResource = () => {
                   {/* Title Preview */}
                   <h3
                     className={`text-lg font-black uppercase tracking-tight transition-colors duration-300 break-words ${
-                      resourceName.trim()
+                      resource.title.trim()
                         ? dark
                           ? "text-white"
                           : "text-black"
                         : "text-neutral-400 italic"
                     }`}
                   >
-                    {resourceName.trim() ? resourceName : "Unnamed Resource"}
+                    {resource.title.trim() ? resource.title : "Unnamed Resource"}
                   </h3>
 
                   {/* Resource url preview */}
@@ -324,8 +377,8 @@ const AddResource = () => {
                           : "bg-white border-neutral-200 text-neutral-600"
                       }`}
                     >
-                      {resourceUrl.trim() ? (
-                        <pre className="whitespace-pre-wrap break-all font-semibold">{resourceUrl}</pre>
+                      {resource.url.trim() ? (
+                        <pre className="whitespace-pre-wrap break-all font-semibold">{resource.url}</pre>
                     ) : (
                       <span className="text-neutral-400 italic font-sans">
                         // resource url preview will appear here...
@@ -352,8 +405,8 @@ const AddResource = () => {
                           : "bg-white border-neutral-200 text-neutral-600"
                       }`}
                     >
-                      {description.trim() ? (
-                        <pre className="whitespace-pre-wrap break-all font-semibold">{description}</pre>
+                      {resource.description.trim() ? (
+                        <pre className="whitespace-pre-wrap break-all font-semibold">{resource.description}</pre>
                     ) : (
                       <span className="text-neutral-400 italic font-sans">
                         // description preview will appear here...

--- a/src/pages/ResourceHub/resourcehub/AddResource.jsx
+++ b/src/pages/ResourceHub/resourcehub/AddResource.jsx
@@ -89,7 +89,7 @@ const AddResource = () => {
     >
       <title>Add Resource | DevTasks</title>
       <meta name="description" content="Create and manage development resources." />
-      
+
       <div
         className={`absolute top-[-10%] right-[-10%] w-[300px] sm:w-[500px] h-[300px] sm:h-[500px] rounded-full blur-[100px] opacity-30 transition-colors duration-500 ${
           dark ? "bg-zinc-800" : "bg-neutral-200"
@@ -128,8 +128,8 @@ const AddResource = () => {
           <ThemeToggle />
         </div>
 
-        <div className="p-6 sm:p-10">
-          <form className="space-y-6 flex flex-col justify-between">
+        <div className="p-6 sm:p-10 flex flex-col md:flex-row gap-4p-6 sm:p-10 grid grid-cols-1 lg:grid-cols-12 gap-8 sm:gap-10">
+          <form className="space-y-6 flex flex-col justify-between lg:col-span-7">
             <div className="space-y-5">
               <div className="group flex flex-col space-y-2">
                 <label
@@ -257,6 +257,126 @@ const AddResource = () => {
               </button>
             </div>
           </form>
+
+          <div className="flex flex-col justify-start lg:col-span-5">
+            <div className="flex flex-col h-full">
+              <span
+                className={`text-xs font-black uppercase tracking-widest mb-2 transition-colors ${
+                  dark ? "text-zinc-500" : "text-neutral-400"
+                }`}
+              >
+                Live Board Preview
+              </span>
+
+              {/* Resource Card Mock */}
+              <div
+                className={`p-6 rounded-[24px] border flex flex-col justify-between min-h-[280px] h-full transition-all duration-500 relative overflow-hidden group ${
+                  dark ? "bg-zinc-950/40 border-zinc-800" : "bg-neutral-50 border-neutral-250"
+                }`}
+              >
+                {/* Visual grid background pattern */}
+                <div className="absolute inset-0 opacity-[0.03] dark:opacity-[0.05] pointer-events-none bg-[radial-gradient(#808080_1px,transparent_1px)] [background-size:16px_16px]" />
+
+                <div className="relative z-10 space-y-4">
+                  {/* Category Header */}
+                  <div className="flex items-center justify-between">
+                    <div
+                      className={`flex items-center gap-2 px-3 py-1.5 rounded-full border text-[10px] font-black uppercase tracking-wider transition-all duration-300 ${dark ? "bg-white text-black" : "bg-black text-white"}
+                        `}
+                    >
+                      <span>{category}</span>
+                    </div>
+
+                    <div className="flex items-center gap-1.5">
+                      <div className="w-2.5 h-2.5 rounded-full bg-neutral-300 dark:bg-zinc-700" />
+                      <div className="w-2.5 h-2.5 rounded-full bg-neutral-300 dark:bg-zinc-700" />
+                    </div>
+                  </div>
+
+                  {/* Title Preview */}
+                  <h3
+                    className={`text-lg font-black uppercase tracking-tight transition-colors duration-300 break-words ${
+                      resourceName.trim()
+                        ? dark
+                          ? "text-white"
+                          : "text-black"
+                        : "text-neutral-400 italic"
+                    }`}
+                  >
+                    {resourceName.trim() ? resourceName : "Unnamed Resource"}
+                  </h3>
+
+                  {/* Resource url preview */}
+                  <div className={`flex flex-col gap-2`}>
+                    <label
+                      className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
+                        dark
+                          ? "text-zinc-400 group-focus-within:text-white"
+                          : "text-neutral-500 group-focus-within:text-black"
+                      }`}
+                    >
+                      Url
+                    </label>
+                    <div
+                      className={`p-4 rounded-xl border font-mono text-xs overflow-x-auto max-h-[70px] transition-all duration-300 select-all ${
+                        dark
+                          ? "bg-zinc-900 border-zinc-800 text-zinc-300"
+                          : "bg-white border-neutral-200 text-neutral-600"
+                      }`}
+                    >
+                      {resourceUrl.trim() ? (
+                        <pre className="whitespace-pre-wrap break-all font-semibold">{resourceUrl}</pre>
+                    ) : (
+                      <span className="text-neutral-400 italic font-sans">
+                        // resource url preview will appear here...
+                      </span>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Description preview */}
+                  <div className={`flex flex-col gap-2`}>
+                    <label
+                      className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
+                        dark
+                          ? "text-zinc-400 group-focus-within:text-white"
+                          : "text-neutral-500 group-focus-within:text-black"
+                      }`}
+                    >
+                      Description
+                    </label>
+                    <div
+                      className={`p-4 rounded-xl border font-mono text-xs overflow-x-auto max-h-[140px] transition-all duration-300 select-all ${
+                        dark
+                          ? "bg-zinc-900 border-zinc-800 text-zinc-300"
+                          : "bg-white border-neutral-200 text-neutral-600"
+                      }`}
+                    >
+                      {description.trim() ? (
+                        <pre className="whitespace-pre-wrap break-all font-semibold">{description}</pre>
+                    ) : (
+                      <span className="text-neutral-400 italic font-sans">
+                        // description preview will appear here...
+                      </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Footer indicators */}
+                <div className="relative z-10 pt-4 flex items-center justify-between text-[10px] font-black uppercase tracking-widest text-neutral-400 border-t border-neutral-100 dark:border-zinc-800 mt-4">
+                  <span>Resource Preview</span>
+                  <div className="flex items-center gap-1.5 opacity-60 hover:opacity-100 cursor-not-allowed">
+                    <span>Copy</span>
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth={2.5} viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+
+            </div>
+          </div>
         </div>
 
         <div className="px-6 sm:px-10 pb-8 flex items-center border-t border-neutral-100 dark:border-zinc-800 pt-6">

--- a/src/pages/ResourceHub/resourcehub/AddResource.jsx
+++ b/src/pages/ResourceHub/resourcehub/AddResource.jsx
@@ -1,16 +1,85 @@
-import { useState } from "react";
-import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { useTheme } from "../../../context/ThemeContext";
 import ThemeToggle from "../../../components/ThemeToggle";
+import { toast } from "sonner";
 
-const categories = ["FIGMA", "API", "DOCS", "STAGING"];
+const categories = ["GENERAL", "LOCALHOST", "STAGING", "FIGMA", "DOCUMENTATION"];
 
 const AddResource = () => {
+  const navigate = useNavigate();
   const { dark } = useTheme();
   const [resourceName, setResourceName] = useState("");
   const [resourceUrl, setResourceUrl] = useState("");
   const [description, setDescription] = useState("");
-  const [category, setCategory] = useState("FIGMA");
+  const [category, setCategory] = useState("GENERAL");
+
+  const [resources, setResources] = useState(() => {
+    const existingResources = localStorage.getItem("dev_resources");
+    return existingResources ? JSON.parse(existingResources) : [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem("dev_resources", JSON.stringify(resources));
+  }, [resources]);
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    console.log(event);
+    const validationErrors = [];
+    const trimedResourceName = resourceName.trim();
+    const trimedResourceUrl = resourceUrl.trim();
+
+    if (!trimedResourceName) {
+      validationErrors.push("・Resource name");
+    }
+    if (!trimedResourceUrl) {
+      validationErrors.push("・Resource url");
+    }
+    if (!category) {
+      validationErrors.push("・Category tag");
+    }
+
+    if (validationErrors.length > 0) {
+      toast.error("The following items are either not filled in or not selected.",
+        { 
+          description: (
+            <div>
+              {validationErrors.map((message) => (
+                <div>{message}</div>
+              ))}
+            </div>
+          )
+        }
+      );
+      return;
+    }
+
+    const newResource = {
+      id: crypto.randomUUID(),
+      title: trimedResourceName,
+      url: trimedResourceUrl,
+      category,
+      description,
+      createdAt: new Date().toISOString()
+    }
+
+    setResources([...resources, newResource]); 
+
+    toast.success("Resource successfully added.",
+      {
+        action: {
+          label: "view list",
+          onClick: () => navigate("/resourcehub/list")
+        }
+      }
+    );
+
+    setResourceName("");
+    setResourceUrl("");
+    setCategory("GENERAL");
+    setDescription("");
+  };
 
   return (
     <div
@@ -173,7 +242,8 @@ const AddResource = () => {
                 Cancel
               </Link>
               <button
-                type="button"
+                type="submit"
+                onClick={handleSubmit}
                 className={`w-full py-4 rounded-2xl text-xs font-black uppercase tracking-widest border transition-all duration-300 transform active:scale-95 ${
                   dark
                     ? "bg-white border-white text-black hover:bg-neutral-200"


### PR DESCRIPTION
## 📝 Description
This PR implements the Resource Hub add and edit functionality, featuring live preview support for a better user experience.

It includes:
- a complete workflow for adding new resources to the Resource Hub
- a live board preview that updates as users type resource details
- support for editing existing resources through `/resourcehub/edit/:id`
- metadata and UX refinements for the resource add/edit page, including creation/edit-state handling and success messaging

## 🔗 Related Issue
Closes #166

## 🎯 Type of Change
- [ ] `fix`: Bug fix
- [x] `feat`: New feature
- [x] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist
- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [x] Added screenshots (if UI was changed) 📸
- [x] Tested locally on the latest version 🧪

## 📸 Screenshots (if applicable)
| Before | After |
| --- | --- |
| <img width="1772" height="857" alt="image" src="https://github.com/user-attachments/assets/c40497c8-dabe-4aa0-b062-ad317c7e0484" /> <img width="1656" height="821" alt="image" src="https://github.com/user-attachments/assets/a400d22c-ff7e-4805-bc4b-cdbd2aeb8a6c" /> | <img width="1761" height="850" alt="image" src="https://github.com/user-attachments/assets/24e73871-cdd7-46cd-8cf4-314e9e32c519" /> <img width="1651" height="825" alt="image" src="https://github.com/user-attachments/assets/bfbc32e6-c6ff-4e14-aba7-ed1ad4057f7c" /> |
