### PR TITLE
feat: implement regular expression tester tool

### DIFF
--- a/src/pages/DevUtilities/devutilities/RegexTester.jsx
+++ b/src/pages/DevUtilities/devutilities/RegexTester.jsx
@@ -1,10 +1,127 @@
+import { useState, useCallback, useMemo } from "react";
 import { Link } from "react-router-dom";
+import { toast } from "sonner";
 import { useTheme } from "../../../context/ThemeContext";
 
-const FLAGS = ["g", "i", "m", "s"];
+const FLAG_DEFS = [
+  { key: "g", label: "g", title: "Global — find all matches" },
+  { key: "i", label: "i", title: "Case-insensitive" },
+  { key: "m", label: "m", title: "Multiline — ^ and $ match line boundaries" },
+];
+
+function buildSegments(text, matches) {
+  const segments = [];
+  let cursor = 0;
+  for (let i = 0; i < matches.length; i++) {
+    const { index, end, value } = matches[i];
+    if (index > cursor) {
+      segments.push({ type: "text", value: text.slice(cursor, index), key: `pre-${i}` });
+    }
+    segments.push({ type: "match", value, key: `match-${i}` });
+    cursor = end;
+  }
+  if (cursor < text.length) {
+    segments.push({ type: "text", value: text.slice(cursor), key: "tail" });
+  }
+  return segments;
+}
+
+const HighlightedText = ({ text, matches, dark }) => {
+  if (!matches.length) {
+    return (
+      <span className={dark ? "text-zinc-400" : "text-zinc-600"}>{text}</span>
+    );
+  }
+  const segments = buildSegments(text, matches);
+  return (
+    <>
+      {segments.map((seg) =>
+        seg.type === "match" ? (
+          <mark
+            key={seg.key}
+            className={`rounded px-0.5 font-semibold not-italic ${
+              dark ? "bg-zinc-600 text-white" : "bg-neutral-300 text-black"
+            }`}
+          >
+            {seg.value}
+          </mark>
+        ) : (
+          <span key={seg.key} className={dark ? "text-zinc-300" : "text-zinc-700"}>
+            {seg.value}
+          </span>
+        )
+      )}
+    </>
+  );
+};
 
 const RegexTester = () => {
   const { dark } = useTheme();
+
+  const [pattern, setPattern] = useState("");
+  const [testText, setTestText] = useState("");
+  const [flags, setFlags] = useState({ g: true, i: false, m: false });
+
+  const activeFlags = useMemo(
+    () => FLAG_DEFS.filter((f) => flags[f.key]).map((f) => f.key).join(""),
+    [flags]
+  );
+
+  const regexLiteral = pattern ? `/${pattern}/${activeFlags}` : "";
+
+  const { matchResults, error } = useMemo(() => {
+    if (!pattern) return { matchResults: [], error: null };
+    try {
+      const loopFlags = activeFlags.includes("g") ? activeFlags : activeFlags + "g";
+      const regex = new RegExp(pattern, loopFlags);
+      const results = [];
+      let match;
+      while ((match = regex.exec(testText)) !== null) {
+        results.push({
+          matchIndex: results.length + 1,
+          index: match.index,
+          end: match.index + match[0].length,
+          value: match[0],
+          groups: Array.from(match)
+            .slice(1)
+            .map((g, i) => ({ groupNum: i + 1, value: g ?? "undefined" })),
+        });
+        if (match[0].length === 0) regex.lastIndex++;
+        if (!flags.g) break;
+      }
+      return { matchResults: results, error: null };
+    } catch (e) {
+      return { matchResults: [], error: e.message };
+    }
+  }, [pattern, testText, flags, activeFlags]);
+
+  const toggleFlag = useCallback((key) => {
+    setFlags((prev) => ({ ...prev, [key]: !prev[key] }));
+  }, []);
+
+  const handleClear = useCallback(() => {
+    setPattern("");
+    setTestText("");
+    setFlags({ g: true, i: false, m: false });
+  }, []);
+
+  const handleCopyPattern = useCallback(() => {
+    if (!pattern) {
+      toast.error("No pattern to copy.");
+      return;
+    }
+    navigator.clipboard
+      .writeText(regexLiteral)
+      .then(() => toast.success("Pattern copied to clipboard!"))
+      .catch(() => toast.error("Failed to copy to clipboard."));
+  }, [pattern, regexLiteral]);
+
+  const matchCountLabel =
+    !pattern || error
+      ? null
+      : matchResults.length === 0
+      ? "No matches found"
+      : `${matchResults.length} match${matchResults.length !== 1 ? "es" : ""} found`;
 
   return (
     <div
@@ -44,48 +161,54 @@ const RegexTester = () => {
         />
 
         {/* Header */}
-        <div className="flex items-start justify-between px-6 sm:px-10 pt-8 sm:pt-10 gap-4">
-          <div>
-            <h1
-              className={`text-2xl sm:text-3xl font-black uppercase tracking-tight transition-colors duration-300 ${
-                dark ? "text-white" : "text-black"
-              }`}
-            >
-              Regex Tester
-            </h1>
-          </div>
+        <div className="px-6 sm:px-10 pt-8 sm:pt-10">
+          <h1
+            className={`text-2xl sm:text-3xl font-black uppercase tracking-tight transition-colors duration-300 ${
+              dark ? "text-white" : "text-black"
+            }`}
+          >
+            Regex Tester
+          </h1>
         </div>
 
         {/* Content area */}
         <div className="p-6 sm:p-10">
 
-          {/* Two-column grid */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8 mb-6">
+          {/* ── TOP PANEL: Pattern + Flags + Literal preview ── */}
+          <div className="flex flex-col gap-4 mb-6">
 
-            {/* LEFT: Pattern + Flags + Test String */}
-            <div className="flex flex-col gap-4">
+            {/* Pattern input */}
+            <div className="group flex flex-col space-y-2">
+              <label
+                className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
+                  dark
+                    ? "text-zinc-400 group-focus-within:text-white"
+                    : "text-neutral-500 group-focus-within:text-black"
+                }`}
+              >
+                Pattern
+              </label>
+              <input
+                type="text"
+                value={pattern}
+                onChange={(e) => setPattern(e.target.value)}
+                placeholder="e.g. \b\w+\b or (\w+): (\d+)"
+                spellCheck={false}
+                autoComplete="off"
+                className={`w-full px-4 py-3 rounded-2xl border text-sm font-mono outline-none transition-all duration-300 ${
+                  error
+                    ? dark
+                      ? "bg-zinc-950 border-zinc-600 text-zinc-200 focus:border-zinc-400 focus:ring-1 focus:ring-zinc-400"
+                      : "bg-neutral-50 border-neutral-400 text-zinc-800 focus:border-neutral-500 focus:ring-1 focus:ring-neutral-500"
+                    : dark
+                    ? "bg-zinc-950 border-zinc-800 text-zinc-200 placeholder-zinc-600 focus:border-white focus:ring-1 focus:ring-white"
+                    : "bg-neutral-50 border-neutral-200 text-zinc-800 placeholder-neutral-400 focus:border-black focus:ring-1 focus:ring-black"
+                }`}
+              />
+            </div>
 
-              {/* Pattern input */}
-              <div className="group flex flex-col space-y-2">
-                <label
-                  className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
-                    dark
-                      ? "text-zinc-400 group-focus-within:text-white"
-                      : "text-neutral-500 group-focus-within:text-black"
-                  }`}
-                >
-                  Pattern
-                </label>
-                <input
-                  type="text"
-                  placeholder="/your-regex-pattern/"
-                  className={`w-full px-4 py-3 rounded-2xl border text-sm font-mono outline-none transition-all duration-300 ${
-                    dark
-                      ? "bg-zinc-950 border-zinc-800 text-zinc-200 placeholder-zinc-600 focus:border-white focus:ring-1 focus:ring-white"
-                      : "bg-neutral-50 border-neutral-200 text-zinc-800 placeholder-neutral-400 focus:border-black focus:ring-1 focus:ring-black"
-                  }`}
-                />
-              </div>
+            {/* Flags + Literal preview row */}
+            <div className="flex flex-wrap items-end gap-6">
 
               {/* Flags */}
               <div className="flex flex-col space-y-2">
@@ -97,46 +220,82 @@ const RegexTester = () => {
                   Flags
                 </label>
                 <div className="flex flex-wrap gap-2">
-                  {FLAGS.map((flag) => (
+                  {FLAG_DEFS.map((flag) => (
                     <button
-                      key={flag}
+                      key={flag.key}
                       type="button"
+                      title={flag.title}
+                      onClick={() => toggleFlag(flag.key)}
                       className={`px-4 py-2 rounded-xl border font-black text-xs uppercase tracking-widest transition-all duration-300 active:scale-95 ${
-                        dark
+                        flags[flag.key]
+                          ? dark
+                            ? "bg-white text-black border-white"
+                            : "bg-black text-white border-black"
+                          : dark
                           ? "border-zinc-700 text-zinc-300 hover:border-white hover:text-white"
                           : "border-neutral-200 text-zinc-600 hover:border-black hover:text-black"
                       }`}
                     >
-                      {flag}
+                      {flag.label}
                     </button>
                   ))}
                 </div>
               </div>
 
-              {/* Test String */}
-              <div className="group flex flex-col space-y-2">
-                <label
-                  className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
-                    dark
-                      ? "text-zinc-400 group-focus-within:text-white"
-                      : "text-neutral-500 group-focus-within:text-black"
-                  }`}
-                >
-                  Test String
-                </label>
-                <textarea
-                  placeholder="Enter test string here..."
-                  className={`w-full h-40 px-4 py-3 rounded-2xl border text-sm font-mono outline-none transition-all duration-300 resize-none ${
-                    dark
-                      ? "bg-zinc-950 border-zinc-800 text-zinc-200 placeholder-zinc-600 focus:border-white focus:ring-1 focus:ring-white"
-                      : "bg-neutral-50 border-neutral-200 text-zinc-800 placeholder-neutral-400 focus:border-black focus:ring-1 focus:ring-black"
-                  }`}
-                />
-              </div>
+              {/* Regex literal preview */}
+              {regexLiteral && (
+                <div className="flex flex-col space-y-2">
+                  <label
+                    className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
+                      dark ? "text-zinc-400" : "text-neutral-500"
+                    }`}
+                  >
+                    Regex Literal
+                  </label>
+                  <span
+                    className={`font-mono text-sm px-4 py-2 rounded-2xl border select-all transition-colors duration-300 ${
+                      error
+                        ? dark
+                          ? "bg-zinc-950 border-zinc-700 text-zinc-500 line-through"
+                          : "bg-neutral-100 border-neutral-300 text-zinc-400 line-through"
+                        : dark
+                        ? "bg-zinc-950 border-zinc-700 text-zinc-300"
+                        : "bg-neutral-100 border-neutral-300 text-zinc-600"
+                    }`}
+                  >
+                    {regexLiteral}
+                  </span>
+                </div>
+              )}
 
             </div>
 
-            {/* RIGHT: Matches output */}
+            {/* Error banner */}
+            {error && (
+              <div
+                className={`px-4 py-3 rounded-2xl border text-sm font-mono transition-colors duration-300 ${
+                  dark
+                    ? "bg-zinc-950 border-zinc-700 text-zinc-400"
+                    : "bg-neutral-100 border-neutral-300 text-zinc-500"
+                }`}
+              >
+                <span
+                  className={`font-black uppercase tracking-widest text-xs mr-2 ${
+                    dark ? "text-zinc-300" : "text-zinc-700"
+                  }`}
+                >
+                  Invalid Regex:
+                </span>
+                {error}
+              </div>
+            )}
+
+          </div>
+
+          {/* ── TWO-COLUMN GRID ── */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8 mb-6">
+
+            {/* LEFT: Test Text */}
             <div className="group flex flex-col space-y-2">
               <label
                 className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
@@ -145,46 +304,137 @@ const RegexTester = () => {
                     : "text-neutral-500 group-focus-within:text-black"
                 }`}
               >
-                Matches
+                Test Text
               </label>
               <textarea
-                readOnly
-                placeholder="Match results will appear here..."
-                className={`w-full h-64 px-4 py-3 rounded-2xl border text-sm font-mono outline-none transition-all duration-300 resize-none ${
+                value={testText}
+                onChange={(e) => setTestText(e.target.value)}
+                placeholder="Enter test string here..."
+                spellCheck={false}
+                className={`w-full h-72 px-4 py-3 rounded-2xl border text-sm font-mono outline-none transition-all duration-300 resize-none ${
                   dark
-                    ? "bg-zinc-950/50 border-zinc-800 text-zinc-500"
-                    : "bg-neutral-100 border-neutral-200 text-zinc-400"
+                    ? "bg-zinc-950 border-zinc-800 text-zinc-200 placeholder-zinc-600 focus:border-white focus:ring-1 focus:ring-white"
+                    : "bg-neutral-50 border-neutral-200 text-zinc-800 placeholder-neutral-400 focus:border-black focus:ring-1 focus:ring-black"
                 }`}
               />
-              <div className="flex justify-end">
-                <button
-                  type="button"
-                  className={`w-40 px-4 py-2 rounded-xl border font-bold text-sm text-center transition-all duration-300 active:scale-95 ${
-                    dark
-                      ? "border-white text-white hover:bg-white hover:text-black"
-                      : "border-black text-black hover:bg-black hover:text-white"
+            </div>
+
+            {/* RIGHT: Match stats + highlighted preview + match list */}
+            <div className="flex flex-col gap-4">
+
+              {/* Match count label */}
+              <div>
+                <label
+                  className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
+                    dark ? "text-zinc-400" : "text-neutral-500"
                   }`}
                 >
-                  Copy
-                </button>
+                  {matchCountLabel ?? "Matches"}
+                </label>
               </div>
+
+              {/* Highlighted preview */}
+              <div
+                className={`w-full min-h-28 px-4 py-3 rounded-2xl border text-sm font-mono transition-all duration-300 leading-relaxed whitespace-pre-wrap break-all ${
+                  dark
+                    ? "bg-zinc-950/50 border-zinc-800"
+                    : "bg-neutral-100 border-neutral-200"
+                }`}
+              >
+                {testText ? (
+                  <HighlightedText
+                    text={testText}
+                    matches={error ? [] : matchResults}
+                    dark={dark}
+                  />
+                ) : (
+                  <span className={dark ? "text-zinc-600" : "text-zinc-400"}>
+                    Highlighted matches will appear here...
+                  </span>
+                )}
+              </div>
+
+              {/* Match list with capturing groups */}
+              {!error && matchResults.length > 0 && (
+                <div
+                  className={`rounded-2xl border overflow-hidden transition-colors duration-300 ${
+                    dark ? "border-zinc-800" : "border-neutral-200"
+                  }`}
+                >
+                  <div
+                    className={`max-h-48 overflow-y-auto divide-y ${
+                      dark ? "divide-zinc-800" : "divide-neutral-100"
+                    }`}
+                  >
+                    {matchResults.map((match) => (
+                      <div
+                        key={match.matchIndex}
+                        className={`px-4 py-3 text-xs font-mono transition-colors duration-300 ${
+                          dark ? "text-zinc-300" : "text-zinc-700"
+                        }`}
+                      >
+                        <div className="flex items-baseline gap-2 mb-1">
+                          <span className="font-black uppercase tracking-widest">
+                            Match {match.matchIndex}
+                          </span>
+                          <span
+                            className={`text-xs font-normal normal-case tracking-normal ${
+                              dark ? "text-zinc-500" : "text-zinc-400"
+                            }`}
+                          >
+                            index {match.index}–{match.end - 1}
+                          </span>
+                        </div>
+                        <div
+                          className={`truncate ${
+                            dark ? "text-zinc-200" : "text-zinc-800"
+                          }`}
+                        >
+                          &ldquo;{match.value}&rdquo;
+                        </div>
+                        {match.groups.length > 0 && (
+                          <div
+                            className={`mt-1.5 pl-3 border-l flex flex-col gap-0.5 ${
+                              dark ? "border-zinc-700" : "border-neutral-300"
+                            }`}
+                          >
+                            {match.groups.map((group) => (
+                              <div
+                                key={group.groupNum}
+                                className={dark ? "text-zinc-500" : "text-zinc-400"}
+                              >
+                                Group {group.groupNum}: {group.value}
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
             </div>
 
           </div>
 
-          {/* Action Buttons */}
+          {/* ── ACTION BUTTONS ── */}
           <div className="flex flex-wrap justify-center gap-4">
-            {["Test", "Clear"].map((btn) => (
+            {[
+              { label: "Clear", action: handleClear },
+              { label: "Copy Pattern", action: handleCopyPattern },
+            ].map(({ label, action }) => (
               <button
-                key={btn}
+                key={label}
                 type="button"
-                className={`px-6 py-3 rounded-xl text-xs font-black uppercase tracking-widest border transition-all duration-200 hover:scale-105 ${
+                onClick={action}
+                className={`px-6 py-3 rounded-xl text-xs font-black uppercase tracking-widest border transition-all duration-200 hover:scale-105 active:scale-95 ${
                   dark
                     ? "bg-zinc-800 border-zinc-700 text-zinc-300 hover:text-white hover:border-zinc-500"
                     : "bg-white border-neutral-200 text-zinc-600 hover:text-black hover:border-neutral-400"
                 }`}
               >
-                {btn}
+                {label}
               </button>
             ))}
           </div>


### PR DESCRIPTION
## 📝 Description
Implements the fully interactive Regex Tester utility in `src/pages/DevUtilities/devutilities/RegexTester.jsx`.

The page was previously a static placeholder with no state, no logic, and no wired-up controls. This PR replaces it with a complete regex workbench:

- **State management** via `useState` for `pattern`, `testText`, and `flags` (g / i / m), with reactive match computation via `useMemo`.
- **Safe regex compilation** wrapped in `try/catch` — invalid patterns surface a clear error banner and strike-through the literal preview instead of crashing.
- **Zero-length match protection** — `regex.lastIndex` is incremented manually when a match has length 0, preventing infinite `exec` loops on patterns like `a*` or `^`.
- **Match highlighting** built as safe JSX `<span>` / `<mark>` element arrays via a `buildSegments` helper — no `dangerouslySetInnerHTML`.
- **Match list** showing per-match index range, matched string, and any capturing groups nested beneath each entry.
- **Flag toggles** (g, i, m) with filled/inverted active state following the monochrome design system.
- **Regex literal preview** (e.g. `/pattern/gi`) that appears inline next to the flags and strikes through on error.
- **Clear** resets all state to defaults.
- **Copy Pattern** writes the full regex literal to the clipboard with `sonner` toast feedback.
- Full dark/light mode support throughout using `ThemeContext`.

## 🔗 Related Issue
Closes #180 

## 🎯 Type of Change
- [ ] `fix`: Bug fix
- [x] `feat`: New feature
- [ ] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist
- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [x] Added screenshots (if UI was changed) 📸
- [x] Tested locally on the latest version 🧪

## 📸 Screenshots (if applicable)
Regex Example:
<img width="1880" height="896" alt="regex-example" src="https://github.com/user-attachments/assets/c9e2d54f-25ae-4a5c-ae21-be53f3c9bfc1" />
