### PR TITLE
feat: add uuid generator utility

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,7 @@ import RegexTester from "./pages/DevUtilities/devutilities/RegexTester";
 import JsonFormatter from "./pages/DevUtilities/devutilities/JsonFormatter";
 import Base64Url from "./pages/DevUtilities/devutilities/Base64Url";
 import TimestampConverter from "./pages/DevUtilities/devutilities/TimestampConverter";
+import UuidGenerator from "./pages/DevUtilities/devutilities/UuidGenerator";
 
 import { ThemeProvider, useTheme } from "./context/ThemeContext";
 import { CategoryProvider } from "./context/CategoryContext";
@@ -102,6 +103,7 @@ function AppInner({ toggleHUD, hudVisible }) {
         <Route path="/devutilities/json" element={<JsonFormatter />} />
         <Route path="/devutilities/base64" element={<Base64Url />} />
         <Route path="/devutilities/timestamp" element={<TimestampConverter />} />
+        <Route path="/devutilities/uuid" element={<UuidGenerator />} />
       </Routes>
       </div>
     </div>

--- a/src/pages/DevUtilities/DevUtilities.jsx
+++ b/src/pages/DevUtilities/DevUtilities.jsx
@@ -59,6 +59,16 @@ const DevUtilities = () => {
         </svg>
       ),
     },
+    {
+      title: "UUID Generator",
+      description: "Generate RFC4122-compliant v4 UUIDs offline with formatting options.",
+      path: "/devutilities/uuid",
+      icon: (
+        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+        </svg>
+      ),
+    },
   ];
 
   return (
@@ -83,10 +93,10 @@ const DevUtilities = () => {
 
             <div className="w-full max-w-sm">
               <div className="text-xs font-black uppercase tracking-widest mb-2">
-                Utility Status: 4 Active Utilities
+                Utility Status: 5 Active Utilities
               </div>
               <div className="text-[10px] font-bold text-gray-500 uppercase truncate">
-                REGEXP • JSON • BASE64/URL • TIMESTAMP
+                REGEXP • JSON • BASE64/URL • TIMESTAMP • UUID
               </div>
             </div>
           </div>

--- a/src/pages/DevUtilities/devutilities/UuidGenerator.jsx
+++ b/src/pages/DevUtilities/devutilities/UuidGenerator.jsx
@@ -1,0 +1,248 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { toast } from "sonner";
+import { useTheme } from "../../../context/ThemeContext";
+
+const UuidGenerator = () => {
+  const { dark } = useTheme();
+  const [quantity, setQuantity] = useState(1);
+  const [uppercase, setUppercase] = useState(false);
+  const [noHyphens, setNoHyphens] = useState(false);
+  const [output, setOutput] = useState("");
+
+  const generateUUIDv4 = () => {
+    if (crypto && crypto.randomUUID) {
+      return crypto.randomUUID();
+    }
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
+      const r = (Math.random() * 16) | 0;
+      const v = c === "x" ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  };
+
+  const handleGenerate = () => {
+    try {
+      const count = Math.min(Math.max(1, parseInt(quantity) || 1), 1000);
+      let newUuids = [];
+      for (let i = 0; i < count; i++) {
+        let uuid = generateUUIDv4();
+        if (uppercase) uuid = uuid.toUpperCase();
+        if (noHyphens) uuid = uuid.replace(/-/g, "");
+        newUuids.push(uuid);
+      }
+      setOutput(newUuids.join("\n"));
+    } catch (error) {
+      toast.error("Failed to generate UUIDs");
+    }
+  };
+
+  const handleClear = () => {
+    setOutput("");
+  };
+
+  const handleCopy = async () => {
+    try {
+      if (!output) return;
+      await navigator.clipboard.writeText(output);
+      toast.success("Copied to clipboard");
+    } catch (error) {
+      toast.error("Failed to copy");
+    }
+  };
+
+  return (
+    <div
+      className={`h-[calc(100vh-76px)] px-4 sm:px-6 py-6 transition-colors duration-300 overflow-hidden relative flex flex-col justify-center ${
+        dark ? "bg-zinc-950" : "bg-[#F7F7F7]"
+      }`}
+    >
+      <title>UUID Generator — Dev Utilities</title>
+      <meta
+        name="description"
+        content="Generate valid v4 UUIDs offline quickly and easily."
+      />
+
+      <div
+        className={`absolute top-[-10%] right-[-10%] w-[300px] sm:w-[500px] h-[300px] sm:h-[500px] rounded-full blur-[100px] opacity-30 transition-colors duration-500 ${
+          dark ? "bg-zinc-800" : "bg-neutral-200"
+        }`}
+      />
+      <div
+        className={`absolute bottom-[-10%] left-[-10%] w-[300px] sm:w-[500px] h-[300px] sm:h-[500px] rounded-full blur-[100px] opacity-30 transition-colors duration-500 ${
+          dark ? "bg-zinc-900" : "bg-neutral-100"
+        }`}
+      />
+
+      <div
+        className={`relative z-10 w-[85%] max-w-none mx-auto rounded-[32px] border shadow-xl flex flex-col max-h-full overflow-hidden transition-all duration-300 ${
+          dark ? "bg-zinc-900 border-zinc-800" : "bg-white border-neutral-200"
+        }`}
+      >
+        <div
+          className={`h-2 w-full transition-colors duration-500 ${
+            dark ? "bg-white" : "bg-black"
+          }`}
+        />
+
+        <div className="px-5 sm:px-8 pt-6 sm:pt-8 flex items-center gap-3">
+          <Link
+            to="/devutilities"
+            className={`p-2.5 rounded-xl border transition-all duration-200 active:scale-95 flex items-center justify-center shrink-0 ${
+              dark
+                ? "bg-zinc-800/80 border-zinc-700 text-zinc-300 hover:text-white hover:border-zinc-600"
+                : "bg-white border-neutral-200 text-neutral-600 hover:text-black hover:border-neutral-350"
+            }`}
+            title="Back to Workspace"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2.5}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </Link>
+          <h1
+            className={`text-xl sm:text-2xl font-black uppercase tracking-tight transition-colors duration-300 ${
+              dark ? "text-white" : "text-black"
+            }`}
+          >
+            UUID Generator
+          </h1>
+        </div>
+
+        <div className="w-full md:h-[464px] p-5 sm:p-8 overflow-y-auto">
+          <div className="w-full h-full flex flex-col md:flex-row gap-4">
+            <div className="group w-full flex flex-col space-y-4">
+              <div className="flex flex-col space-y-2">
+                <label
+                  className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
+                    dark
+                      ? "text-zinc-400 group-focus-within:text-white"
+                      : "text-neutral-500 group-focus-within:text-black"
+                  }`}
+                >
+                  Quantity (Max 1000)
+                </label>
+                <input
+                  type="number"
+                  min="1"
+                  max="1000"
+                  value={quantity}
+                  onChange={(e) => setQuantity(e.target.value)}
+                  className={`w-full px-4 py-3 rounded-2xl border text-sm outline-none transition-all duration-300 ${
+                    dark
+                      ? "bg-zinc-950 border-zinc-800 text-white placeholder-zinc-700 focus:border-white focus:ring-1 focus:ring-white"
+                      : "bg-neutral-50 border-neutral-300 text-black placeholder-neutral-400 focus:border-black focus:ring-1 focus:ring-black"
+                  }`}
+                />
+              </div>
+
+              <div className="flex flex-col space-y-3 pt-2">
+                <label className="flex items-center gap-3 cursor-pointer group/label">
+                  <input
+                    type="checkbox"
+                    checked={uppercase}
+                    onChange={(e) => setUppercase(e.target.checked)}
+                    className="w-5 h-5 rounded-md border-zinc-300 accent-black dark:accent-white cursor-pointer"
+                  />
+                  <span
+                    className={`text-sm font-bold transition-colors ${
+                      dark ? "text-zinc-300 group-hover/label:text-white" : "text-neutral-600 group-hover/label:text-black"
+                    }`}
+                  >
+                    Uppercase Output
+                  </span>
+                </label>
+                <label className="flex items-center gap-3 cursor-pointer group/label">
+                  <input
+                    type="checkbox"
+                    checked={noHyphens}
+                    onChange={(e) => setNoHyphens(e.target.checked)}
+                    className="w-5 h-5 rounded-md border-zinc-300 accent-black dark:accent-white cursor-pointer"
+                  />
+                  <span
+                    className={`text-sm font-bold transition-colors ${
+                      dark ? "text-zinc-300 group-hover/label:text-white" : "text-neutral-600 group-hover/label:text-black"
+                    }`}
+                  >
+                    Remove Hyphens
+                  </span>
+                </label>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3 pt-4">
+                <button
+                  onClick={handleGenerate}
+                  type="button"
+                  className={`w-full px-4 py-3 rounded-xl border font-bold text-sm text-center transition-all duration-300 active:scale-95 ${
+                    dark
+                      ? "border-white bg-white text-black hover:bg-zinc-200 hover:border-zinc-200"
+                      : "border-black bg-black text-white hover:bg-zinc-800 hover:border-zinc-800"
+                  }`}
+                >
+                  Generate
+                </button>
+                <button
+                  onClick={handleClear}
+                  type="button"
+                  className={`w-full px-4 py-3 rounded-xl border font-bold text-sm text-center transition-all duration-300 active:scale-95 ${
+                    dark
+                      ? "border-zinc-700 text-zinc-300 hover:bg-zinc-800 hover:text-white"
+                      : "border-neutral-300 text-neutral-600 hover:bg-neutral-100 hover:text-black"
+                  }`}
+                >
+                  Clear
+                </button>
+              </div>
+            </div>
+
+            <div className="group w-full flex flex-col space-y-2 mt-6 md:mt-0">
+              <label
+                className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
+                  dark
+                    ? "text-zinc-400 group-focus-within:text-white"
+                    : "text-neutral-500 group-focus-within:text-black"
+                }`}
+              >
+                Output
+              </label>
+              <textarea
+                value={output}
+                readOnly
+                placeholder="Generated UUIDs will appear here..."
+                className={`md:h-full h-40 px-4 py-3 rounded-2xl border text-sm outline-none transition-all duration-300 resize-none font-mono ${
+                  dark
+                    ? "bg-zinc-950 border-zinc-800 text-white placeholder-zinc-700 focus:border-white focus:ring-1 focus:ring-white"
+                    : "bg-neutral-50 border-neutral-300 text-black placeholder-neutral-400 focus:border-black focus:ring-1 focus:ring-black"
+                }`}
+              />
+              <div className="flex justify-end pt-2">
+                <button
+                  onClick={handleCopy}
+                  type="button"
+                  className={`w-full md:w-40 px-4 py-2 rounded-xl border font-bold text-sm text-center transition-all duration-300 active:scale-95 ${
+                    dark
+                      ? "border-white text-white hover:bg-white hover:text-black"
+                      : "border-black text-black hover:bg-black hover:text-white"
+                  }`}
+                >
+                  Copy
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UuidGenerator;


### PR DESCRIPTION
## 📝 Description
This PR adds a new offline developer tool, the **UUID Generator**, to the Dev Utilities Sandbox. It allows users to rapidly generate UUIDs entirely client side. 

Key features include:
- Generating multiple UUIDs at once (up to 1000).
- Checkboxes to toggle uppercase/lowercase output and remove hyphens.
- One-click copy to clipboard.
- The UI perfectly matches the existing monochrome design system, including responsive layouts and full dark/light mode support.

## 🔗 Related Issue
Closes #193

## 🎯 Type of Change
- [ ] `fix`: Bug fix
- [x] `feat`: New feature
- [x] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist
- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [x] Added screenshots (if UI was changed) 📸 *(Make sure to drag and drop your screenshots below!)*
- [x] Tested locally on the latest version 🧪

## 📸 Screenshots (if applicable)
| Before | 
<img width="1710" height="1107" alt="Screenshot 2026-06-12 at 2 34 13 PM" src="https://github.com/user-attachments/assets/4f045c0b-b3ec-41a7-8a12-0d6317b1d172" />

| After |
<img width="1710" height="1107" alt="Screenshot 2026-06-12 at 2 34 47 PM" src="https://github.com/user-attachments/assets/c3a96ddf-568a-47b1-a92f-3d2fd3afa8e9" />
<img width="1710" height="1107" alt="Screenshot 2026-06-12 at 2 34 56 PM" src="https://github.com/user-attachments/assets/4125f195-3856-4d07-b469-033e4424b40e" />
<img width="1710" height="1107" alt="Screenshot 2026-06-12 at 2 35 16 PM" src="https://github.com/user-attachments/assets/397428d4-1c2f-4239-a76f-dc71de89323c" />
