### PR TITLE
feat: implement base64 and url converter functionality

### DIFF
--- a/src/pages/DevUtilities/devutilities/Base64Url.jsx
+++ b/src/pages/DevUtilities/devutilities/Base64Url.jsx
@@ -1,8 +1,90 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
+import { toast } from "sonner";
 import { useTheme } from "../../../context/ThemeContext";
+
+const MODES = [
+  { key: "base64", label: "Base64" },
+  { key: "url", label: "URL" },
+];
+
+const encodeBase64 = (str) => {
+  const bytes = new TextEncoder().encode(str);
+  let binary = "";
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+};
+
+const decodeBase64 = (str) => {
+  const binary = atob(str);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+};
 
 const Base64Url = () => {
   const { dark } = useTheme();
+  const [mode, setMode] = useState("base64");
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState("");
+
+  const handleModeChange = (newMode) => {
+    setMode(newMode);
+    setOutput("");
+  };
+
+  const handleEncode = () => {
+    if (!input.trim()) return;
+    try {
+      if (mode === "base64") {
+        setOutput(encodeBase64(input));
+      } else {
+        setOutput(encodeURIComponent(input));
+      }
+    } catch (error) {
+      toast.error("Failed to encode input.");
+    }
+  };
+
+  const handleDecode = () => {
+    if (!input.trim()) return;
+    try {
+      if (mode === "base64") {
+        setOutput(decodeBase64(input));
+      } else {
+        setOutput(decodeURIComponent(input));
+      }
+    } catch (error) {
+      toast.error(
+        mode === "base64"
+          ? "Invalid Base64 string."
+          : "Invalid URL-encoded string."
+      );
+    }
+  };
+
+  const handleClear = () => {
+    setInput("");
+    setOutput("");
+  };
+
+  const handleCopy = async () => {
+    if (!output) return;
+    try {
+      await navigator.clipboard.writeText(output);
+      toast.success("Copied to clipboard");
+    } catch (error) {
+      toast.error("Failed to copy");
+    }
+  };
+
+  const actionButtons = [
+    { label: "Encode", onClick: handleEncode },
+    { label: "Decode", onClick: handleDecode },
+    { label: "Clear", onClick: handleClear },
+    { label: "Copy", onClick: handleCopy },
+  ];
 
   return (
     <div
@@ -27,6 +109,32 @@ const Base64Url = () => {
           >
             Base64 Encoder & Decoder
           </h1>
+
+          {/* Mode Selector */}
+          <div
+            className={`flex items-center gap-2 p-1 border rounded-2xl ${
+              dark ? "border-zinc-700 bg-zinc-800" : "border-neutral-200 bg-neutral-50"
+            }`}
+          >
+            {MODES.map((opt) => (
+              <button
+                key={opt.key}
+                type="button"
+                onClick={() => handleModeChange(opt.key)}
+                className={`px-4 py-2 rounded-xl text-xs font-black uppercase tracking-widest transition-all duration-200 cursor-pointer ${
+                  mode === opt.key
+                    ? dark
+                      ? "bg-white text-black"
+                      : "bg-black text-white"
+                    : dark
+                      ? "text-neutral-400 hover:text-white"
+                      : "text-neutral-400 hover:text-black"
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
         </div>
 
         {/* Content Area */}
@@ -42,14 +150,15 @@ const Base64Url = () => {
                   Input
                 </label>
                 <button className={`text-xs font-bold transition-colors ${dark ? "text-zinc-500 hover:text-white" : "text-zinc-400 hover:text-black"}`}>
-                
                 </button>
               </div>
               <textarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
                 className={`w-full h-64 p-4 rounded-xl border resize-none focus:outline-none focus:ring-2 focus:ring-zinc-500 transition-colors ${
                   dark ? "bg-zinc-950 border-zinc-800 text-zinc-200" : "bg-neutral-50 border-neutral-200 text-zinc-800"
                 }`}
-                placeholder="Enter text or Base64 here"
+                placeholder={mode === "base64" ? "Enter text or Base64 here" : "Enter text or URL-encoded string here"}
               ></textarea>
             </div>
 
@@ -59,9 +168,12 @@ const Base64Url = () => {
                 Output
               </label>
               <textarea
+                value={output}
                 readOnly
                 className={`w-full h-64 p-4 rounded-xl border resize-none focus:outline-none transition-colors ${
-                  dark ? "bg-zinc-900/50 border-zinc-800 text-zinc-500" : "bg-neutral-100 border-neutral-200 text-zinc-400"
+                  dark
+                    ? `bg-zinc-900/50 border-zinc-800 ${output ? "text-zinc-200" : "text-zinc-500"}`
+                    : `bg-neutral-100 border-neutral-200 ${output ? "text-zinc-800" : "text-zinc-400"}`
                 }`}
                 placeholder="Result will appear here..."
               ></textarea>
@@ -71,16 +183,18 @@ const Base64Url = () => {
 
           {/* Action Buttons (Centered at bottom) */}
           <div className="flex flex-wrap justify-center gap-4">
-            {["Encode", "Decode"].map((btn) => (
+            {actionButtons.map((btn) => (
               <button
-                key={btn}
+                key={btn.label}
+                type="button"
+                onClick={btn.onClick}
                 className={`px-6 py-3 rounded-xl text-xs font-black uppercase tracking-widest border transition-all duration-200 hover:scale-105 ${
                   dark
                     ? "bg-zinc-800 border-zinc-700 text-zinc-300 hover:text-white hover:border-zinc-500"
                     : "bg-white border-neutral-200 text-zinc-600 hover:text-black hover:border-neutral-400"
                 }`}
               >
-                {btn}
+                {btn.label}
               </button>
             ))}
           </div>


### PR DESCRIPTION
## 📝 Description
Implements full functionality for the Base64 & URL Converter utility page
(`src/pages/DevUtilities/devutilities/Base64Url.jsx`), which previously only
had static UI.

Changes to `src/pages/DevUtilities/devutilities/Base64Url.jsx`:
- Added `mode`, `input`, and `output` state via `useState`.
- Added a mode selector toggle (Base64 / URL), styled with the existing
  monochrome pill pattern used elsewhere in the app.
- Wired both textareas to state (input editable, output read-only).
- Implemented **Encode**:
  - Base64 mode → Unicode-safe encoding via `TextEncoder` + `btoa`.
  - URL mode → `encodeURIComponent()`.
- Implemented **Decode**:
  - Base64 mode → `atob` + `TextDecoder`, wrapped in `try/catch` with a
    Sonner error toast on invalid input.
  - URL mode → `decodeURIComponent()`, wrapped in `try/catch` with a Sonner
    error toast on malformed input.
- Implemented **Clear** — resets both Input and Output fields.
- Implemented **Copy** — copies Output to clipboard via the Clipboard API,
  with success/error Sonner toasts.
- Switching modes clears the Output to avoid showing stale results.

## 🔗 Related Issue
Closes #176 

## 🎯 Type of Change
- [ ] `fix`: Bug fix
- [x] `feat`: New feature
- [ ] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist
- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [x] Added screenshots (if UI was changed) 📸
- [x] Tested locally on the latest version 🧪

## 📸 Screenshots

Base64 Encoding:
<img width="1880" height="896" alt="Base64-encode" src="https://github.com/user-attachments/assets/82bf6d88-cc27-468e-84ae-dda729175f5c" />

Base64 Decoding:
<img width="1880" height="896" alt="Base64-decode" src="https://github.com/user-attachments/assets/2cb4c8b3-a278-4a29-b0bc-2ac536433724" />

Base64 Invalid String while Decoding:
<img width="1880" height="896" alt="Base64-Invalid-decode" src="https://github.com/user-attachments/assets/cf8c14bc-4dc7-40cf-952e-8f9cb7639569" />

URL Encoding:
<img width="1880" height="896" alt="URL-encode" src="https://github.com/user-attachments/assets/49c4476e-608a-48e9-90e1-a6c82baeb341" />

URL Decoding:
<img width="1880" height="896" alt="URL-decode" src="https://github.com/user-attachments/assets/ac9adcae-be58-457f-b5bc-084a4f04171e" />

URL Invalid String while Decoding:
<img width="1880" height="896" alt="URL-Invalid-decode" src="https://github.com/user-attachments/assets/b805c43a-8049-4464-9d8f-b7818ec3613e" />