### PR TITLE
feat: implement resource hub data center functionality

### DIFF
--- a/src/pages/ResourceHub/resourcehub/DataCenter.jsx
+++ b/src/pages/ResourceHub/resourcehub/DataCenter.jsx
@@ -1,59 +1,196 @@
-import { useState, useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
+import { toast } from "sonner";
 import { useTheme } from "../../../context/ThemeContext";
+
+const TRACKED_CATEGORIES = [
+  "GENERAL",
+  "LOCALHOST",
+  "STAGING",
+  "FIGMA",
+  "DOCUMENTATION",
+];
+
+const getStoredResources = () => {
+  try {
+    const saved = localStorage.getItem("dev_resources");
+    if (!saved) return [];
+
+    const parsed = JSON.parse(saved);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const getStats = (resources) => {
+  const counts = TRACKED_CATEGORIES.reduce(
+    (acc, category) => ({
+      ...acc,
+      [category]: resources.filter((resource) => resource.category === category)
+        .length,
+    }),
+    {}
+  );
+  const sizeBytes = new Blob([JSON.stringify(resources)]).size;
+
+  return {
+    total: resources.length,
+    counts,
+    estimatedSize:
+      sizeBytes < 1024 ? `${sizeBytes} B` : `~${Math.ceil(sizeBytes / 1024)} KB`,
+  };
+};
+
+const getInitialSnapshot = () => {
+  const storedResources = getStoredResources();
+  return {
+    resources: storedResources,
+    stats: getStats(storedResources),
+  };
+};
+
+const isValidResource = (resource) =>
+  resource &&
+  typeof resource.id !== "undefined" &&
+  typeof resource.title === "string" &&
+  resource.title.trim().length > 0 &&
+  typeof resource.url === "string" &&
+  resource.url.trim().length > 0 &&
+  typeof resource.category === "string" &&
+  resource.category.trim().length > 0 &&
+  typeof resource.createdAt === "string" &&
+  resource.createdAt.trim().length > 0;
+
+const getExportableResources = (resources, exportedAt) =>
+  resources.map((resource, index) => ({
+    ...resource,
+    id: resource.id ?? `resource-${index + 1}`,
+    title: resource.title ?? "",
+    url: resource.url ?? "",
+    category: resource.category ?? "GENERAL",
+    createdAt: resource.createdAt ?? exportedAt,
+  }));
 
 const DataCenter = () => {
   const { dark } = useTheme();
+  const fileInputRef = useRef(null);
 
-  const [resourceStats, setResourceStats] = useState({
-    total: 0,
-    categories: [],
-    estimatedSize: "0 KB",
-  });
+  const [resources, setResources] = useState(() => getInitialSnapshot().resources);
+  const [resourceStats, setResourceStats] = useState(
+    () => getInitialSnapshot().stats
+  );
+
+  const refreshResources = () => {
+    const storedResources = getStoredResources();
+    setResources(storedResources);
+    setResourceStats(getStats(storedResources));
+  };
 
   useEffect(() => {
-    const saved = localStorage.getItem("dev_resources");
-    if (saved) {
-      try {
-        const parsed = JSON.parse(saved);
-        const total = parsed.length;
-        const categoryCounts = {};
-        parsed.forEach((r) => {
-          const cat = r.category || "GENERAL";
-          categoryCounts[cat] = (categoryCounts[cat] || 0) + 1;
-        });
-        const categories = Object.keys(categoryCounts);
-        const sizeBytes = new Blob([saved]).size;
-        const estimatedSize =
-          sizeBytes < 1024
-            ? `${sizeBytes} B`
-            : `~${Math.ceil(sizeBytes / 1024)} KB`;
-        setResourceStats({ total, categories, estimatedSize });
-      } catch {
-        // ignore parse errors
-      }
-    }
+    const handleStorage = (event) => {
+      if (event.key === "dev_resources") refreshResources();
+    };
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
   }, []);
 
-  const categoryDisplay =
-    resourceStats.categories.length > 0
-      ? resourceStats.categories.slice(0, 3).join(", ") +
-        (resourceStats.categories.length > 3 ? "..." : "")
-      : "None";
+  const handleExport = () => {
+    const currentResources = getStoredResources();
+
+    if (currentResources.length === 0) {
+      toast.error("No resources to backup.");
+      return;
+    }
+
+    const exportedAt = new Date().toISOString();
+    const exportableResources = getExportableResources(
+      currentResources,
+      exportedAt
+    );
+
+    const exportData = {
+      exportedAt,
+      resources: exportableResources,
+    };
+
+    const blob = new Blob([JSON.stringify(exportData, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+
+    anchor.href = url;
+    anchor.download = `resources-backup-${Date.now()}.json`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+
+    toast.success(`Exported ${exportableResources.length} resources successfully.`);
+  };
+
+  const handleImport = (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+
+    reader.onload = (readerEvent) => {
+      try {
+        const parsed = JSON.parse(readerEvent.target.result);
+
+        if (!parsed.resources || !Array.isArray(parsed.resources)) {
+          toast.error("Invalid backup file. Missing resources database.");
+          return;
+        }
+
+        if (!parsed.resources.every(isValidResource)) {
+          toast.error(
+            "Validation failed. Each resource needs id, title, url, category, and createdAt."
+          );
+          return;
+        }
+
+        localStorage.setItem("dev_resources", JSON.stringify(parsed.resources));
+        setResources(parsed.resources);
+        setResourceStats(getStats(parsed.resources));
+
+        toast.success(`Import completed. Restored ${parsed.resources.length} resources.`);
+      } catch {
+        toast.error("Invalid JSON file. Please upload a valid DevTasks backup.");
+      }
+    };
+
+    reader.onerror = () => {
+      toast.error("Could not read the selected backup file.");
+    };
+
+    reader.readAsText(file);
+    event.target.value = "";
+  };
+
+  const statCards = [
+    { label: "Total Resources", value: resourceStats.total },
+    ...TRACKED_CATEGORIES.map((category) => ({
+      label: `${category} Resources`,
+      value: resourceStats.counts[category] || 0,
+    })),
+  ];
 
   return (
     <div
-      className={`h-[calc(100vh-76px)] px-4 sm:px-6 py-6 transition-colors duration-300 overflow-hidden relative flex flex-col justify-center ${
+      className={`min-h-[calc(100vh-76px)] px-4 sm:px-6 py-6 transition-colors duration-300 overflow-hidden relative flex flex-col justify-center ${
         dark ? "bg-zinc-950" : "bg-[#F7F7F7]"
       }`}
     >
-      <title>Backup & Restore Data Center | DevTasks</title>
+      <title>Resource Hub Data Center | DevTasks</title>
       <meta
         name="description"
-        content="Export, backup, and restore your DevTasks resources database. Sync your bookmarks, developer links, and guides seamlessly."
+        content="Manage resource backups, restores, and analytics."
       />
 
-      {/* AMBIENT GLOWS */}
       <div
         aria-hidden="true"
         className={`absolute top-[-120px] right-[-120px] w-[280px] sm:w-[420px] h-[280px] sm:h-[420px] rounded-full blur-3xl opacity-40 ${
@@ -67,18 +204,15 @@ const DataCenter = () => {
         }`}
       />
 
-      {/* MAIN GLASS CARD */}
       <div
-        className={`relative z-10 w-full max-w-4xl mx-4 sm:mx-6 md:mx-auto rounded-[32px] border shadow-xl flex flex-col max-h-full overflow-hidden transition-all duration-300 ${
+        className={`relative z-10 w-full max-w-6xl mx-auto rounded-[32px] border shadow-xl flex flex-col max-h-full overflow-hidden backdrop-blur-xl transition-all duration-300 ${
           dark
             ? "bg-zinc-900/80 border-zinc-800"
             : "bg-white/80 border-neutral-200"
         }`}
       >
-        {/* TOP ACCENT BAR */}
         <div className={`h-2 w-full ${dark ? "bg-white" : "bg-black"}`} />
 
-        {/* HEADER */}
         <div className="px-5 sm:px-8 pt-6 sm:pt-8 flex flex-col gap-4">
           <Link
             to="/resourcehub"
@@ -90,79 +224,86 @@ const DataCenter = () => {
           >
             <span>← Back to Workspace</span>
           </Link>
-          <div className="flex items-start justify-between gap-4">
+          <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
             <div>
               <h1
-                className={`text-xl sm:text-2xl font-black uppercase tracking-tight transition-colors duration-300 ${
+                className={`text-2xl sm:text-4xl font-black uppercase tracking-tight transition-colors duration-300 ${
                   dark ? "text-white" : "text-black"
                 }`}
               >
                 Data Center
               </h1>
-              <p className="text-xs text-neutral-400 mt-0.5">
-                Backup & restore your resource hub
+              <p className="text-sm sm:text-base text-neutral-400 mt-2">
+                Manage resource backups, restores, and analytics
               </p>
+            </div>
+            <div className="text-left md:text-right">
+              <div className="text-[10px] font-black tracking-widest text-neutral-400 uppercase">
+                Database Size
+              </div>
+              <div
+                className={`text-sm font-black uppercase mt-1 ${
+                  dark ? "text-zinc-200" : "text-neutral-700"
+                }`}
+              >
+                {resourceStats.estimatedSize}
+              </div>
             </div>
           </div>
         </div>
 
         <div className="overflow-y-auto flex-1 min-h-0">
-          {/* HUB INVENTORY STATS */}
-          <div className="px-5 sm:px-8 pt-6">
+          <section className="px-5 sm:px-8 pt-6">
             <div
-              className={`p-4 rounded-2xl border flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 ${
+              className={`p-4 rounded-2xl border ${
                 dark
                   ? "bg-zinc-950/60 border-zinc-800"
                   : "bg-neutral-50 border-neutral-200"
               }`}
             >
-              <div>
-                <div className="text-[10px] font-black tracking-widest text-neutral-400 uppercase">
-                  Hub Inventory
-                </div>
-                <div
-                  className={`text-base font-black uppercase mt-0.5 ${
-                    dark ? "text-white" : "text-black"
-                  }`}
-                >
-                  {resourceStats.total} links indexed
-                </div>
-              </div>
-
-              <div className="flex flex-wrap gap-2 text-[9px] font-black uppercase tracking-wider">
-                {resourceStats.categories.length > 0 ? (
-                  resourceStats.categories.slice(0, 4).map((cat) => (
-                    <span
-                      key={cat}
-                      className={`px-2 py-1 rounded-lg ${
-                        dark
-                          ? "bg-zinc-800 text-zinc-300"
-                          : "bg-white border border-gray-200 text-gray-700"
-                      }`}
-                    >
-                      {cat}
-                    </span>
-                  ))
-                ) : (
-                  <span
-                    className={`px-2 py-1 rounded-lg ${
-                      dark
-                        ? "bg-zinc-800 text-zinc-500"
-                        : "bg-white border border-gray-200 text-gray-400"
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+                <div>
+                  <div className="text-[10px] font-black tracking-widest text-neutral-400 uppercase">
+                    Resource Statistics
+                  </div>
+                  <div
+                    className={`text-base font-black uppercase mt-0.5 ${
+                      dark ? "text-white" : "text-black"
                     }`}
                   >
-                    No categories
-                  </span>
-                )}
+                    {resourceStats.total} links indexed
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3">
+                {statCards.map(({ label, value }) => (
+                  <div
+                    key={label}
+                    className={`rounded-xl border p-3 ${
+                      dark
+                        ? "bg-zinc-900/70 border-zinc-800"
+                        : "bg-white border-neutral-200"
+                    }`}
+                  >
+                    <div className="text-[9px] font-black uppercase tracking-widest text-neutral-400 leading-snug">
+                      {label}
+                    </div>
+                    <div
+                      className={`text-2xl font-black mt-2 ${
+                        dark ? "text-white" : "text-black"
+                      }`}
+                    >
+                      {value}
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
-          </div>
+          </section>
 
-          {/* DUAL CARD GRID */}
-          <div className="px-5 sm:px-8 py-8">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-
-              {/* EXPORT CARD */}
+          <section className="px-5 sm:px-8 py-8">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
               <div
                 className={`p-6 rounded-[24px] border flex flex-col gap-4 transition-all duration-300 hover:shadow-md ${
                   dark
@@ -199,11 +340,10 @@ const DataCenter = () => {
                       dark ? "text-white" : "text-black"
                     }`}
                   >
-                    Backup Hub
+                    Backup Center
                   </h2>
                 </div>
 
-                {/* SAMPLE DATA ROWS */}
                 <div
                   className={`rounded-xl border p-4 space-y-3 flex-1 ${
                     dark
@@ -212,20 +352,20 @@ const DataCenter = () => {
                   }`}
                 >
                   {[
-                    { label: "Total Links", value: String(resourceStats.total) },
-                    { label: "Categories", value: categoryDisplay },
-                    { label: "Last Backup", value: "Never" },
+                    { label: "Export Format", value: "JSON" },
+                    { label: "Resources", value: String(resources.length) },
+                    { label: "Includes", value: "exportedAt + resources" },
                     { label: "Estimated Size", value: resourceStats.estimatedSize },
                   ].map(({ label, value }) => (
                     <div
                       key={label}
-                      className="flex justify-between items-center"
+                      className="flex justify-between items-center gap-4"
                     >
                       <span className="text-[10px] font-black uppercase tracking-widest text-neutral-400">
                         {label}
                       </span>
                       <span
-                        className={`text-[11px] font-black uppercase ${
+                        className={`text-[11px] font-black uppercase text-right ${
                           dark ? "text-zinc-200" : "text-neutral-700"
                         }`}
                       >
@@ -237,18 +377,18 @@ const DataCenter = () => {
 
                 <button
                   type="button"
-                  aria-label="Download backup"
+                  aria-label="Download resource backup"
+                  onClick={handleExport}
                   className={`w-full py-2.5 rounded-xl text-[10px] font-black uppercase tracking-widest border transition-all duration-300 ${
                     dark
                       ? "bg-white text-black hover:bg-neutral-200 border-white"
                       : "bg-black text-white hover:bg-neutral-800 border-black"
                   }`}
                 >
-                  Download Backup
+                  Export Backup
                 </button>
               </div>
 
-              {/* IMPORT CARD */}
               <div
                 className={`p-6 rounded-[24px] border flex flex-col gap-4 transition-all duration-300 hover:shadow-md ${
                   dark
@@ -285,19 +425,28 @@ const DataCenter = () => {
                       dark ? "text-white" : "text-black"
                     }`}
                   >
-                    Restore Hub
+                    Restore Center
                   </h2>
                 </div>
 
-                {/* DRAG & DROP AREA */}
-                <div
-                  className={`flex-1 min-h-[150px] rounded-xl border-2 border-dashed flex flex-col items-center justify-center gap-3 px-4 py-8 transition-all duration-300 ${
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="application/json,.json"
+                  className="hidden"
+                  onChange={handleImport}
+                />
+
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  className={`flex-1 min-h-[150px] rounded-xl border-2 border-dashed flex flex-col items-center justify-center gap-3 px-4 py-8 text-center transition-all duration-300 ${
                     dark
                       ? "border-zinc-700 hover:border-zinc-500 bg-zinc-950/30 hover:bg-zinc-950/50"
                       : "border-neutral-300 hover:border-neutral-400 bg-white hover:bg-neutral-50"
                   }`}
                 >
-                  <div
+                  <span
                     className={`p-3 rounded-xl ${
                       dark
                         ? "bg-zinc-800 text-zinc-400"
@@ -318,36 +467,43 @@ const DataCenter = () => {
                         d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z"
                       />
                     </svg>
-                  </div>
-                  <div className="text-center">
-                    <p
-                      className={`text-xs font-black uppercase tracking-widest ${
+                  </span>
+                  <span>
+                    <span
+                      className={`block text-xs font-black uppercase tracking-widest ${
                         dark ? "text-zinc-300" : "text-neutral-600"
                       }`}
                     >
-                      Drag & Drop Backup File
-                    </p>
-                    <p className="text-[10px] text-neutral-400 mt-1 font-medium">
-                      or click to browse — JSON files only
-                    </p>
-                  </div>
-                </div>
+                      Select Backup File
+                    </span>
+                    <span className="block text-[10px] text-neutral-400 mt-1 font-medium">
+                      JSON files with a resources array
+                    </span>
+                  </span>
+                </button>
 
-                <button
-                  type="button"
-                  aria-label="Upload backup"
-                  className={`w-full py-2.5 rounded-xl text-[10px] font-black uppercase tracking-widest border transition-all duration-300 ${
+                <div
+                  className={`rounded-xl border p-4 ${
                     dark
-                      ? "bg-zinc-800 border-zinc-700 text-white hover:border-white"
-                      : "bg-white border-neutral-300 text-black hover:border-black"
+                      ? "bg-zinc-950/50 border-zinc-700"
+                      : "bg-white border-neutral-200"
                   }`}
                 >
-                  Upload Backup
-                </button>
+                  <p className="text-[10px] font-black uppercase tracking-widest text-neutral-400">
+                    Restore Information
+                  </p>
+                  <p
+                    className={`text-xs font-medium leading-relaxed mt-2 ${
+                      dark ? "text-zinc-300" : "text-neutral-600"
+                    }`}
+                  >
+                    Imports replace the current dev_resources database after
+                    validating each resource record.
+                  </p>
+                </div>
               </div>
-
             </div>
-          </div>
+          </section>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 📝 Description
Implemented the Resource Hub Data Center as a functional backup, restore, and analytics workspace.

This change replaces the placeholder Data Center page with a complete resource management dashboard that reads from `dev_resources`, displays live resource statistics, exports backups as formatted JSON, and restores valid backup files through a JSON upload flow.

The backup export now includes the required resource fields for every item:

- `id`
- `title`
- `url`
- `category`
- `createdAt`

This solves the issue where users had no way to safely back up or restore their Resource Hub database, and ensures imported/exported data follows a consistent schema.

## 🔗 Related Issue
Closes #171 

## 🎯 Type of Change
- [ ] `fix`: Bug fix
- [x] `feat`: New feature
- [x] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist
- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [ ] Added screenshots (if UI was changed) 📸
- [x] Tested locally on the latest version 🧪

## 🧪 Testing
- Ran `npm run build` successfully.
- Ran targeted lint successfully: