### PR TITLE
feat: add sample data support to dev utilities

### DIFF
--- a/src/pages/DevUtilities/devutilities/Base64Url.jsx
+++ b/src/pages/DevUtilities/devutilities/Base64Url.jsx
@@ -68,7 +68,14 @@ const Base64Url = () => {
     setInput("");
     setOutput("");
   };
-
+  const handleSample = () => {
+   if (mode === "base64") {
+    setInput("SGVsbG8gRGV2VGFza3Mh");
+   } else {
+     setInput("Hello%20DevTasks%21");
+   }
+   setOutput("");
+  };
   const handleCopy = async () => {
     if (!output) return;
     try {
@@ -82,6 +89,7 @@ const Base64Url = () => {
   const actionButtons = [
     { label: "Encode", onClick: handleEncode },
     { label: "Decode", onClick: handleDecode },
+    { label: "Sample", onClick: handleSample },
     { label: "Clear", onClick: handleClear },
     { label: "Copy", onClick: handleCopy },
   ];

--- a/src/pages/DevUtilities/devutilities/JsonFormatter.jsx
+++ b/src/pages/DevUtilities/devutilities/JsonFormatter.jsx
@@ -32,7 +32,15 @@ const JsonFormatter = () => {
     setInput("");
     setOutput("");
   };
-
+  const handleSample = () => {
+  setInput(`{
+  "name": "John Doe",
+  "role": "Developer",
+  "active": true,
+  "skills": ["React", "JavaScript"]
+}`);
+  setOutput("");
+};
   const handleCopy = async () => {
     try {
       if (!output) return;
@@ -46,6 +54,7 @@ const JsonFormatter = () => {
   const buttons = [
     { label: "Format", onClick: handleFormat },
     { label: "Minify", onClick: handleMinify },
+    { label: "Sample", onClick: handleSample },
     { label: "Clear", onClick: handleClear },
   ];
   return (
@@ -125,7 +134,7 @@ const JsonFormatter = () => {
                     : "bg-neutral-50 border-neutral-300 text-black placeholder-neutral-400 focus:border-black focus:ring-1 focus:ring-black"
                 }`}
               />
-              <div className="grid grid-cols-3 gap-3">
+              <div className="grid grid-cols-4 gap-3">
                 {buttons.map((btn) => (
                   <button
                     key={btn.label}

--- a/src/pages/DevUtilities/devutilities/JwtDecoder.jsx
+++ b/src/pages/DevUtilities/devutilities/JwtDecoder.jsx
@@ -55,9 +55,19 @@ const JwtDecoder = () => {
     setError("");
   };
   const handleSample = () => {
-  setInput(
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJyb2xlIjoiRGV2ZWxvcGVyIn0.signature"
-  );
+  const sampleToken =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJyb2xlIjoiRGV2ZWxvcGVyIn0.c2lnbmF0dXJl";
+
+  setInput(sampleToken);
+
+  try {
+    const result = decodeJwt(sampleToken);
+    setDecoded(result);
+    setError("");
+  } catch (err) {
+    setDecoded(null);
+    setError(err.message);
+  }
 };
   const handleCopy = async (data, label) => {
     try {

--- a/src/pages/DevUtilities/devutilities/JwtDecoder.jsx
+++ b/src/pages/DevUtilities/devutilities/JwtDecoder.jsx
@@ -54,7 +54,11 @@ const JwtDecoder = () => {
     setDecoded(null);
     setError("");
   };
-
+  const handleSample = () => {
+  setInput(
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJyb2xlIjoiRGV2ZWxvcGVyIn0.signature"
+  );
+};
   const handleCopy = async (data, label) => {
     try {
       await navigator.clipboard.writeText(JSON.stringify(data, null, 2));
@@ -178,7 +182,7 @@ const JwtDecoder = () => {
                 </div>
               )}
 
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-3 gap-3">
                 <button
                   onClick={handleDecode}
                   type="button"
@@ -190,6 +194,17 @@ const JwtDecoder = () => {
                 >
                   Decode
                 </button>
+                <button
+  onClick={handleSample}
+  type="button"
+  className={`w-full px-4 py-3 rounded-xl border font-bold text-sm text-center transition-all duration-300 active:scale-95 ${
+    dark
+      ? "border-zinc-700 text-zinc-300 hover:bg-zinc-800 hover:text-white"
+      : "border-neutral-300 text-neutral-600 hover:bg-neutral-100 hover:text-black"
+  }`}
+>
+  Sample
+</button>
                 <button
                   onClick={handleClear}
                   type="button"

--- a/src/pages/DevUtilities/devutilities/RegexTester.jsx
+++ b/src/pages/DevUtilities/devutilities/RegexTester.jsx
@@ -104,7 +104,15 @@ const RegexTester = () => {
     setTestText("");
     setFlags({ g: true, i: false, m: false });
   }, []);
-
+  const handleSample = useCallback(() => {
+  setPattern("\\d+");
+  setTestText("Order 123 contains 456 items and 789 products.");
+  setFlags({
+    g: true,
+    i: false,
+    m: false,
+  });
+}, []);
   const handleCopyPattern = useCallback(() => {
     if (!pattern) {
       toast.error("No pattern to copy.");
@@ -292,6 +300,17 @@ const RegexTester = () => {
                   }`}
                 >
                   Clear
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSample}
+                  className={`px-4 py-2 rounded-xl border font-black text-xs uppercase tracking-widest transition-all duration-300 hover:scale-105 active:scale-95 ${
+                   dark
+                    ? "bg-zinc-800 border-zinc-700 text-zinc-300 hover:text-white hover:border-zinc-500"
+                   : "bg-white border-neutral-200 text-zinc-600 hover:text-black hover:border-neutral-400"
+                 }`}
+                >
+                 Sample
                 </button>
                 <button
                   type="button"

--- a/src/pages/DevUtilities/devutilities/TimestampConverter.jsx
+++ b/src/pages/DevUtilities/devutilities/TimestampConverter.jsx
@@ -30,7 +30,9 @@ const TimestampConverter = () => {
     }
     setConvertedTimestamp(Math.floor(date.getTime() / 1000));
   };
-
+  const handleSampleTimestamp = () => {
+  setTimestamp("1704067200");
+};
   const currentUnix = Math.floor(Date.now() / 1000);
 
   const theme = {
@@ -128,12 +130,20 @@ const TimestampConverter = () => {
                 onChange={(e) => setTimestamp(e.target.value)}
                 className={`w-full px-4 py-3 rounded-xl border text-sm ${t.input}`}
               />
+              <div className="flex gap-3">
               <button
                 onClick={handleTimestampConvert}
                 className={`px-5 py-2.5 rounded-xl text-sm font-medium cursor-pointer ${t.button}`}
               >
                 Convert to Date
               </button>
+               <button
+                 onClick={handleSampleTimestamp}
+                 className={`px-5 py-2.5 rounded-xl text-sm font-medium cursor-pointer ${t.button}`}
+               >
+                 Sample
+                </button>
+              </div>
               {convertedDate && (
                 <div
                   className={`px-4 py-3 rounded-xl border text-sm font-mono break-all ${t.result}`}


### PR DESCRIPTION
## 📝 Description

Added sample data support to Dev Utilities so users can quickly explore and test functionality without manually entering data.

### Changes Made

* Added **Sample** button to JSON Formatter
* Added **Sample** button to Regex Tester
* Added **Sample** button to Base64 / URL Utility
* Added **Sample** button to Timestamp Converter
* Added **Sample** button to JWT Decoder

### Benefits

* Improves onboarding experience for new users
* Allows instant testing of utility tools
* Reduces manual data entry
* Maintains existing UI styling and theme support

## 🔗 Related Issue

Closes #211

## 🎯 Type of Change

* [ ] `fix`: Bug fix
* [x] `feat`: New feature
* [ ] `style`: UI/Theme changes (Monochrome)
* [ ] `chore`: Build/Maintenance

## ✅ Checklist

* [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
* [x] Follows Conventional Commits 📜
* [x] Added screenshots (if UI was changed) 📸
* [x] Tested locally on the latest version 🧪

## 📸 Screenshots (if applicable)
JSON Formatter with Sample button and populated sample data:
<img width="1920" height="1080" alt="JsonFormatter-after" src="https://github.com/user-attachments/assets/cad23dd0-77d0-4cc1-8264-3d6e579d050a" />
