### PR TITLE
feat: Add HTML/CSS/JS Code Sandbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-icons": "^5.6.0",
@@ -563,6 +564,29 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1279,6 +1303,14 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
@@ -1548,6 +1580,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2390,6 +2432,19 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -2404,6 +2459,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/ms": {
@@ -2765,6 +2831,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-icons": "^5.6.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,7 @@ import TimestampConverter from "./pages/DevUtilities/devutilities/TimestampConve
 import UuidGenerator from "./pages/DevUtilities/devutilities/UuidGenerator";
 import JwtDecoder from "./pages/DevUtilities/devutilities/JwtDecoder";
 import DiffChecker from "./pages/DevUtilities/devutilities/DiffChecker";
+import CodeSandbox from "./pages/DevUtilities/devutilities/CodeSandbox";
 
 import { ThemeProvider, useTheme } from "./context/ThemeContext";
 import { CategoryProvider } from "./context/CategoryContext";
@@ -108,6 +109,7 @@ function AppInner({ toggleHUD, hudVisible }) {
         <Route path="/devutilities/uuid" element={<UuidGenerator />} />
         <Route path="/devutilities/jwt" element={<JwtDecoder />} />
         <Route path="/devutilities/diff" element={<DiffChecker />} />
+        <Route path="/devutilities/code" element={<CodeSandbox />} />
       </Routes>
       </div>
     </div>

--- a/src/pages/DevUtilities/DevUtilities.jsx
+++ b/src/pages/DevUtilities/DevUtilities.jsx
@@ -89,6 +89,16 @@ const DevUtilities = () => {
         </svg>
       ),
     },
+    {
+      title: "Code Sandbox",
+      description: "Instantly test raw HTML/CSS/JS with a live preview. No local environment required.",
+      path: "/devutilities/code",
+      icon: (
+        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="m16 18 6-6-6-6M8 6l-6 6 6 6" />
+        </svg>
+      ),
+    },
   ];
 
   return (

--- a/src/pages/DevUtilities/devutilities/CodeSandbox.jsx
+++ b/src/pages/DevUtilities/devutilities/CodeSandbox.jsx
@@ -1,0 +1,282 @@
+import { Link, useSearchParams } from "react-router-dom";
+import { useTheme } from "../../../context/ThemeContext";
+import { useCallback, useEffect, useState } from "react";
+import { Editor } from "@monaco-editor/react";
+import { toast } from "sonner";
+
+
+const CodeSandbox = () => {
+  const { dark } = useTheme();
+  const [ searchParams ] = useSearchParams();
+  const [ activeIndex, setActiveIndex ] = useState(0); 
+  const [ html, setHtml ] = useState(`<h1>Hello！</h1>
+<p>Clicking the button changes its color</p>
+<button id="alert-btn">click</button>
+`);
+  const [ css, setCss ] = useState(`body {
+  font-family: sans-serif;
+  text-align: center;
+  padding-top: 50px;
+}
+h1 {
+  color: #333;
+}
+button {
+  padding: 10px 20px;
+  background: #007acc;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}`);
+  const [ js, setJs ] = useState(`const btn = document.getElementById("alert-btn");
+btn.addEventListener("click", () => {
+  document.body.style.backgroundColor = "#e0f7fa";
+  window.alert("The button was clicked.");
+});`);
+  const [ srcDoc, setSrcdoc ] = useState("");
+
+  const tabs = [
+    {title: "html", language: "html", content: html, stateFunc: setHtml},
+    {title: "css", language: "css", content: css, stateFunc: setCss},
+    {title: "js", language: "javascript", content: js, stateFunc: setJs}
+  ];
+
+  const handleBuild = useCallback(() => {
+    const buildSource = `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <meta charset="UTF-8">
+        <style>${css}</style>
+      </head>
+      <body>
+        ${html}
+        <script>${js}<\/script>
+      </body>
+      </html>
+    `;
+    setSrcdoc(buildSource);
+  }, [html, css, js]);
+
+  useEffect(() => {
+    const searchParamHtml = searchParams.get("html");
+    const searchParamCss = searchParams.get("css");
+    const searchParamJs = searchParams.get("js");
+
+    if (searchParamHtml || searchParamCss || searchParamJs) {
+      setHtml(searchParamHtml || "");
+      setCss(searchParamCss || "");
+      setJs(searchParamJs || "");
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      handleBuild()
+    }, 500)
+    
+    return () => clearTimeout(timer);
+  }, [html, css, js]);
+
+  const handleEditorDidMount = (editor) => {
+    const domNode = editor.getDomNode();
+    if (!domNode) return;
+
+    domNode.addEventListener("keydown", (event) => {
+      if (event.key === "/") event.stopPropagation();
+    }, true);
+  };
+
+  const handleClear = () => {
+    setHtml("");
+    setCss("");
+    setJs("");
+  };
+
+  const handleShare = async () => {
+    const queryParams = tabs.filter((tab) => tab.content && tab.content.trim())
+      .map((tab) => `${tab.title}=${encodeURIComponent(tab.content)}`).join("&");
+
+    try {
+      await navigator.clipboard.writeText(`${window.location.origin}${window.location.pathname}?${queryParams}`);
+      toast.success("Share link copied");
+    } catch(error) {
+      console.error("Failed to copy:" + error);
+      toast.error("Failed to copy");
+    }
+  };
+
+  return (
+    <div
+      className={`h-[calc(100vh-76px)] px-4 sm:px-6 py-6 transition-colors duration-300 overflow-hidden relative flex flex-col justify-center ${
+        dark ? "bg-zinc-950" : "bg-[#F7F7F7]"
+      }`}
+    >
+      <title>Code Sandbox — DevTasks</title>
+      <meta
+        name="description"
+        content="Instantly test raw HTML/CSS/JS with a live preview. No local environment required."
+      />
+
+      <div
+        className={`absolute top-[-10%] right-[-10%] w-[300px] sm:w-[500px] h-[300px] sm:h-[500px] rounded-full blur-[100px] opacity-30 transition-colors duration-500 ${
+          dark ? "bg-zinc-800" : "bg-neutral-200"
+        }`}
+      />
+      <div
+        className={`absolute bottom-[-10%] left-[-10%] w-[300px] sm:w-[500px] h-[300px] sm:h-[500px] rounded-full blur-[100px] opacity-30 transition-colors duration-500 ${
+          dark ? "bg-zinc-900" : "bg-neutral-100"
+        }`}
+      />
+
+      <div
+        className={`relative z-10 w-[85%] max-w-none mx-auto rounded-[32px] border shadow-xl flex flex-col max-h-full overflow-hidden transition-all duration-300 ${
+          dark ? "bg-zinc-900 border-zinc-800" : "bg-white border-neutral-200"
+        }`}
+      >
+        <div
+          className={`h-2 w-full transition-colors duration-500 ${
+            dark ? "bg-white" : "bg-black"
+          }`}
+        />
+
+        <div className="px-5 sm:px-8 pt-6 sm:pt-8 flex items-center gap-3">
+          <Link
+            to="/devutilities"
+            className={`p-2.5 rounded-xl border transition-all duration-200 active:scale-95 flex items-center justify-center shrink-0 ${
+              dark
+                ? "bg-zinc-800/80 border-zinc-700 text-zinc-300 hover:text-white hover:border-zinc-600"
+                : "bg-white border-neutral-200 text-neutral-600 hover:text-black hover:border-neutral-350"
+            }`}
+            title="Back to Workspace"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2.5}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </Link>
+          <h1
+            className={`text-xl sm:text-2xl font-black uppercase tracking-tight transition-colors duration-300 ${
+              dark ? "text-white" : "text-black"
+            }`}
+          >
+            Code Sandbox
+          </h1>
+        </div>
+
+        <div className="w-full md:h-[464px] p-5 sm:p-8 overflow-y-auto">
+          <div className="w-full h-full flex flex-col md:flex-row gap-4">
+
+            {/* LEFT: Input Area */}
+            <div
+              className="group w-full flex flex-col space-y-4"
+            >
+              <div
+                className="flex justify-between border-b border-gray-200 py-1"
+              >
+                <div className="flex gap-1.5">
+                  {tabs.map((tab, index) => {
+                    const isActive = activeIndex === index;
+                    return (
+                      <button
+                        key={index}
+                        role="tab"
+                        aria-selected={isActive}
+                        onClick={() => setActiveIndex(index)}
+                        className={`text-[10px] sm:text-xs font-black uppercase tracking-widest px-3.5 py-2 rounded-xl transition-all duration-200 whitespace-nowrap cursor-pointer ${
+                          isActive
+                            ? dark
+                              ? "bg-white text-black border border-white"
+                              : "bg-black text-white border border-black"
+                            : dark
+                              ? "text-zinc-400 hover:text-white bg-zinc-900/40 hover:bg-zinc-800/40 border border-zinc-800/60"
+                              : "text-neutral-500 hover:text-black bg-neutral-50 hover:bg-neutral-100 border border-neutral-200/60"
+                        }`}
+                      >
+                        {tab.title}
+                      </button>
+                    );
+                  })}
+                </div>
+                <div className="flex gap-1.5">
+                  <button
+                    type="button"
+                    onClick={handleShare}
+                    className={`text-[10px] sm:text-xs font-black uppercase tracking-widest px-3.5 py-2 rounded-xl transition-all duration-200 whitespace-nowrap cursor-pointer ${
+                      dark
+                          ? "text-zinc-400 hover:text-white bg-zinc-900/40 hover:bg-zinc-800/40 border border-zinc-800/60"
+                          : "text-neutral-500 hover:text-black bg-neutral-50 hover:bg-neutral-100 border border-neutral-200/60"
+                    }`}
+                  >
+                    Share
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleClear}
+                    className={`text-[10px] sm:text-xs font-black uppercase tracking-widest px-3.5 py-2 rounded-xl transition-all duration-200 whitespace-nowrap cursor-pointer ${
+                      dark
+                          ? "text-zinc-400 hover:text-white bg-zinc-900/40 hover:bg-zinc-800/40 border border-zinc-800/60"
+                          : "text-neutral-500 hover:text-black bg-neutral-50 hover:bg-neutral-100 border border-neutral-200/60"
+                    }`}
+                  >
+                    Clear
+                  </button>
+                </div>
+              </div>
+
+              <div role="tabpanel"
+                className="h-full"
+              >
+                <Editor
+                  theme={dark ? "vs-dark": "light"}
+                  path={tabs[activeIndex].title}
+                  language={tabs[activeIndex].language}
+                  value={tabs[activeIndex].content}
+                  onChange={(value) => tabs[activeIndex].stateFunc(value)}
+                  onMount={handleEditorDidMount}
+                />
+              </div>
+            </div>
+
+            {/* RIGHT: Preview Area */}
+            <div
+              className="w-full flex flex-col space-y-2"
+            >
+              <label
+                  className={`text-xs font-black uppercase tracking-widest transition-colors duration-300 ${
+                    dark
+                      ? "text-zinc-400 group-focus-within:text-white"
+                      : "text-neutral-500 group-focus-within:text-black"
+                  }`}
+              >
+                LIVE PREVIEW
+              </label>
+              <iframe
+                title="Live preview"
+                className={`md:h-full h-40 px-4 py-3 rounded-2xl border text-sm font-mono outline-none transition-all duration-300 resize-none ${
+                  dark
+                    ? "bg-zinc-950 border-zinc-800 text-white placeholder-zinc-700 focus:border-white focus:ring-1 focus:ring-white"
+                    : "bg-neutral-50 border-neutral-300 text-black placeholder-neutral-400 focus:border-black focus:ring-1 focus:ring-black"
+                }`}
+                srcDoc={srcDoc}
+                sandbox="allow-scripts allow-modals"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CodeSandbox;


### PR DESCRIPTION
## 📝 Description
Add a new **Code Sandbox** utility that lets users write and preview raw HTML, CSS, and JavaScript in the browser without a local setup.
 
This PR:
- adds a Monaco Editor-based sandbox page for HTML/CSS/JS editing
- provides a live preview with iframe-based rendering
- supports clearing code and sharing sandbox content through URL query parameters
- exposes the new utility from the Dev Utilities page
- registers the new route and adds the Monaco editor dependency

## 🔗 Related Issue
Closes #219

## 🎯 Type of Change
- [ ] `fix`: Bug fix
- [x] `feat`: New feature
- [ ] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist
- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [ ] Added screenshots (if UI was changed) 📸
- [ ] Tested locally on the latest version 🧪

## 📸 Screenshots (if applicable)
| Before | After |
| --- | --- |
| <img width="1717" height="868" alt="image" src="https://github.com/user-attachments/assets/5b04540a-394d-4f4e-a9e0-c07ce9fec0eb" /> | <img width="1746" height="862" alt="image" src="https://github.com/user-attachments/assets/3c1ada97-c342-478a-b3b4-2c86429cafb4" /> |

<img width="1787" height="846" alt="image" src="https://github.com/user-attachments/assets/6bd462d0-34c9-453c-aadf-9dcef596454b" />

<img width="1766" height="858" alt="image" src="https://github.com/user-attachments/assets/093001e0-75ca-4896-82bd-738670fd3fd6" />

