### PR TITLE
fix: correct broken nested ternaries causing wrong light/dark mode styling in ListTasks

### DIFF
--- a/src/pages/TaskManagement/taskmanage/ListTasks.jsx
+++ b/src/pages/TaskManagement/taskmanage/ListTasks.jsx
@@ -373,8 +373,6 @@ const ListTasks = () => {
                   : dark
                     ? "border-zinc-600 text-neutral-300 hover:border-white hover:text-white"
                     : "border-neutral-300 text-neutral-600 hover:border-black hover:text-black"
-                  ? "border-zinc-600 text-neutral-300 hover:border-white hover:text-white"
-                  : "border-neutral-300 text-neutral-600 hover:border-black hover:text-black"
               }`}
             >
               Date
@@ -390,8 +388,6 @@ const ListTasks = () => {
                   : dark
                     ? "border-zinc-600 text-neutral-300 hover:border-white hover:text-white"
                     : "border-neutral-300 text-neutral-600 hover:border-black hover:text-black"
-                  ? "border-zinc-600 text-neutral-300 hover:border-white hover:text-white"
-                  : "border-neutral-300 text-neutral-600 hover:border-black hover:text-black"
               }`}
             >
               Priority
@@ -407,8 +403,6 @@ const ListTasks = () => {
                   : dark
                     ? "border-zinc-600 text-neutral-300 hover:border-white hover:text-white"
                     : "border-neutral-300 text-neutral-600 hover:border-black hover:text-black"
-                  ? "border-zinc-600 text-neutral-300 hover:border-white hover:text-white"
-                  : "border-neutral-300 text-neutral-600 hover:border-black hover:text-black"
               }`}
             >
               A–Z
@@ -448,8 +442,6 @@ const ListTasks = () => {
                     : dark
                       ? "bg-transparent text-neutral-400 hover:text-white border border-transparent hover:border-zinc-600"
                       : "bg-transparent text-neutral-400 hover:text-black border border-transparent hover:border-neutral-300"
-                    ? "bg-transparent text-neutral-400 hover:text-white border border-transparent hover:border-zinc-600"
-                    : "bg-transparent text-neutral-400 hover:text-black border border-transparent hover:border-neutral-300"
                 }`}
               >
                 {f} ({taskCounts[f]})
@@ -534,8 +526,6 @@ const ListTasks = () => {
                               : dark
                                 ? "text-white"
                                 : "text-black"
-                              ? "text-white"
-                              : "text-black"
                           }`}
                         >
                           {task.text}
@@ -586,8 +576,6 @@ const ListTasks = () => {
                                       : dark
                                         ? "text-neutral-300 hover:bg-zinc-700"
                                         : "text-neutral-700 hover:bg-neutral-100"
-                                      ? "text-neutral-300 hover:bg-zinc-700"
-                                      : "text-neutral-700 hover:bg-neutral-100"
                                   }`}
                                 >
                                   {cat}
@@ -606,8 +594,6 @@ const ListTasks = () => {
                                 : task.priority === "MEDIUM"
                                   ? "bg-yellow-500/10 text-yellow-600"
                                   : "bg-blue-500/10 text-blue-500"
-                                ? "bg-yellow-500/10 text-yellow-600"
-                                : "bg-blue-500/10 text-blue-500"
                             }`}
                           >
                             {task.priority}


### PR DESCRIPTION
## 📝 Description
Fixes #227 — several `className` template literals in `src/pages/TaskManagement/taskmanage/ListTasks.jsx` had a malformed nested ternary of the shape `cond ? A : (dark ? B : C) ? D : E`. Since `(dark ? B : C)` always evaluates to a truthy string, the trailing `? D : E` always resolved to `D`, leaking dark-mode classes into light mode (and vice versa).

### What Changed
Removed the dead trailing `? X : Y` segment in all 7 affected expressions:
- Date / Priority / A–Z sort buttons
- ALL / ACTIVE / COMPLETED filter buttons
- Task text color (was always white in light mode for incomplete tasks)
- Category dropdown items
- Priority badge (LOW always rendered as yellow/MEDIUM color instead of blue)

### Verified
Reproduced and confirmed visually in the browser (light mode): before the fix, incomplete task text rendered near-invisible white-on-white, and LOW-priority badges rendered yellow instead of blue. Both render correctly after the fix.

## 🔗 Related Issue
Closes #227

## 🎯 Type of Change
- [x] `fix`: Bug fix

## ✅ Checklist
- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows Conventional Commits 📜
- [x] Tested locally on the latest version 🧪