### PR TITLE
feat: add markdown live previewer utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "crypto-js": "^4.2.0",
+        "marked": "^18.0.5",
         "qrcode": "^1.5.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -79,7 +80,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -289,36 +289,12 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/core/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/runtime": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1290,7 +1266,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1304,13 +1279,6 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
-    },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -1344,7 +1312,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1496,7 +1463,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1668,15 +1634,6 @@
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
-    "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.347",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.347.tgz",
@@ -1733,7 +1690,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2543,15 +2499,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
-      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/minimatch": {
@@ -2568,17 +2524,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "dompurify": "3.2.7",
-        "marked": "14.0.0"
       }
     },
     "node_modules/ms": {
@@ -2712,7 +2657,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2749,7 +2693,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2808,7 +2751,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2818,7 +2760,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3137,7 +3078,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3375,7 +3315,6 @@
       "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "crypto-js": "^4.2.0",
+        "dompurify": "^3.4.11",
         "marked": "^18.0.5",
         "qrcode": "^1.5.4",
         "react": "^19.2.5",
@@ -23,6 +24,7 @@
         "@emnapi/runtime": "^1.11.1",
         "@eslint/js": "^10.0.1",
         "@tailwindcss/postcss": "^4.2.4",
+        "@tailwindcss/typography": "^0.5.20",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -1228,6 +1230,19 @@
         "tailwindcss": "4.2.4"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1279,6 +1294,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -1577,6 +1599,19 @@
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1633,6 +1668,15 @@
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.347",
@@ -2702,6 +2746,20 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -3071,6 +3129,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.10",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "crypto-js": "^4.2.0",
+    "marked": "^18.0.5",
     "qrcode": "^1.5.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "crypto-js": "^4.2.0",
+    "dompurify": "^3.4.11",
     "marked": "^18.0.5",
     "qrcode": "^1.5.4",
     "react": "^19.2.5",
@@ -25,6 +26,7 @@
     "@emnapi/runtime": "^1.11.1",
     "@eslint/js": "^10.0.1",
     "@tailwindcss/postcss": "^4.2.4",
+    "@tailwindcss/typography": "^0.5.20",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import DataCenterResource from "./pages/ResourceHub/resourcehub/DataCenter";
 import DevUtilities from "./pages/DevUtilities/DevUtilities";
 import RegexTester from "./pages/DevUtilities/devutilities/RegexTester";
 import JsonFormatter from "./pages/DevUtilities/devutilities/JsonFormatter";
+import MarkdownPreviewer from "./pages/DevUtilities/devutilities/MarkdownPreviewer";
 import Base64Url from "./pages/DevUtilities/devutilities/Base64Url";
 import TimestampConverter from "./pages/DevUtilities/devutilities/TimestampConverter";
 import UuidGenerator from "./pages/DevUtilities/devutilities/UuidGenerator";
@@ -125,6 +126,7 @@ function AppInner({ toggleHUD, hudVisible }) {
             <Route path="/devutilities" element={<DevUtilities />} />
             <Route path="/devutilities/regex" element={<RegexTester />} />
             <Route path="/devutilities/json" element={<JsonFormatter />} />
+            <Route path="/devutilities/markdown" element = {<MarkdownPreviewer/>} />
             <Route path="/devutilities/base64" element={<Base64Url />} />
             <Route path="/devutilities/timestamp" element={<TimestampConverter />} />
             <Route path="/devutilities/uuid" element={<UuidGenerator />} />

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 /* Override 100vh height constraints for inner pages to fit within navbar space and avoid duplicate scrollbars */
 .navbar-layout-content .min-h-screen {

--- a/src/pages/DevUtilities/DevUtilities.jsx
+++ b/src/pages/DevUtilities/DevUtilities.jsx
@@ -21,111 +21,253 @@ const DevUtilities = () => {
   const cards = [
     {
       title: "Regex Tester",
-      description: "Test regular expressions with flags, highlights, matching text, and capturing groups.",
+      description:
+        "Test regular expressions with flags, highlights, matching text, and capturing groups.",
       path: "/devutilities/regex",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+          />
         </svg>
       ),
     },
     {
       title: "JSON Formatter",
-      description: "Validate JSON string formats, structure code outputs, beautify spacing, or minify data.",
+      description:
+        "Validate JSON string formats, structure code outputs, beautify spacing, or minify data.",
       path: "/devutilities/json",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
+          />
         </svg>
       ),
     },
     {
       title: "Base64 / URL",
-      description: "Encode and decode binary string fragments, escape special URL query variables, and test strings.",
+      description:
+        "Encode and decode binary string fragments, escape special URL query variables, and test strings.",
       path: "/devutilities/base64",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+          />
         </svg>
       ),
     },
     {
       title: "Timestamp",
-      description: "Convert epoch/unix values to human-readable datetime formats and parse date strings.",
+      description:
+        "Convert epoch/unix values to human-readable datetime formats and parse date strings.",
       path: "/devutilities/timestamp",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
         </svg>
       ),
     },
     {
       title: "UUID Generator",
-      description: "Generate RFC4122-compliant v4 UUIDs offline with formatting options.",
+      description:
+        "Generate RFC4122-compliant v4 UUIDs offline with formatting options.",
       path: "/devutilities/uuid",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
+          />
         </svg>
       ),
     },
     {
       title: "JWT Decoder",
-      description: "Decode and inspect JSON Web Token header and payload data directly in the browser, completely offline.",
+      description:
+        "Decode and inspect JSON Web Token header and payload data directly in the browser, completely offline.",
       path: "/devutilities/jwt",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+          />
         </svg>
       ),
     },
     {
       title: "Diff Checker",
-      description: "Compare two text blocks and highlight added, removed, and unchanged lines in split or inline view.",
+      description:
+        "Compare two text blocks and highlight added, removed, and unchanged lines in split or inline view.",
       path: "/devutilities/diff",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
+          />
         </svg>
       ),
     },
     {
       title: "Code Sandbox",
-      description: "Instantly test raw HTML/CSS/JS with a live preview. No local environment required.",
+      description:
+        "Instantly test raw HTML/CSS/JS with a live preview. No local environment required.",
       path: "/devutilities/code",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="m16 18 6-6-6-6M8 6l-6 6 6 6" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="m16 18 6-6-6-6M8 6l-6 6 6 6"
+          />
         </svg>
       ),
     },
     {
       title: "Hash Generator",
-      description: "Generate MD5, SHA-1, SHA-256, and SHA-512 cryptographic hashes directly in the browser.",
+      description:
+        "Generate MD5, SHA-1, SHA-256, and SHA-512 cryptographic hashes directly in the browser.",
       path: "/devutilities/hash",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4"
+          />
         </svg>
       ),
     },
     {
       title: "Color Converter & Contrast Checker",
-      description: "Convert HEX, RGB, HSL, and CMYK colors, generate palettes, and verify WCAG contrast offline.",
+      description:
+        "Convert HEX, RGB, HSL, and CMYK colors, generate palettes, and verify WCAG contrast offline.",
       path: "/devutilities/color",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3a9 9 0 100 18 9 9 0 000-18zm0 0c1.5 2 2 4 2 6s-.5 4-2 6c-1.5-2-2-4-2-6s.5-4 2-6zm-6.36 4.64c2.08.83 3.8 2.55 4.64 4.64-2.09-.83-3.81-2.55-4.64-4.64zm12.72 0c-.83 2.09-2.55 3.81-4.64 4.64.83-2.09 2.55-3.81 4.64-4.64z" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 3a9 9 0 100 18 9 9 0 000-18zm0 0c1.5 2 2 4 2 6s-.5 4-2 6c-1.5-2-2-4-2-6s.5-4 2-6zm-6.36 4.64c2.08.83 3.8 2.55 4.64 4.64-2.09-.83-3.81-2.55-4.64-4.64zm12.72 0c-.83 2.09-2.55 3.81-4.64 4.64.83-2.09 2.55-3.81 4.64-4.64z"
+          />
         </svg>
       ),
     },
     {
       title: "QR Code Generator",
-      description: "Create customizable QR codes from text or URLs with color and size options. Fully offline.",
+      description:
+        "Create customizable QR codes from text or URLs with color and size options. Fully offline.",
       path: "/devutilities/qrcode",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 3h7v7H3V3zm11 0h7v7h-7V3zM3 14h7v7H3v-7zm13 0h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3-6h1v1h-1v-1z" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3 3h7v7H3V3zm11 0h7v7h-7V3zM3 14h7v7H3v-7zm13 0h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3-6h1v1h-1v-1z"
+          />
+        </svg>
+      ),
+    },
+    {
+      title: "Markdown Previewer",
+      description:
+        "Write markdown and instantly preview rendered HTML output with support for headings, lists, links, code blocks, and more.",
+      path: "/devutilities/markdown",
+      icon: (
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M5 6h14a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2zm2 3v6l3-3 3 3V9m4 0v6m0-6h2"
+          />
         </svg>
       ),
     },
@@ -222,8 +364,6 @@ const DevUtilities = () => {
             ))}
           </div>
         </div>
-
-
       </div>
     </div>
   );

--- a/src/pages/DevUtilities/devutilities/MarkdownPreviewer.jsx
+++ b/src/pages/DevUtilities/devutilities/MarkdownPreviewer.jsx
@@ -1,0 +1,180 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { toast } from "sonner";
+import { useTheme } from "../../../context/ThemeContext";
+import { marked } from "marked";
+
+const MarkdownPreviewer = () => {
+  const { dark } = useTheme();
+
+  const sampleMarkdown = `# DevTasks Markdown Previewer
+
+## Features
+
+- Live Preview
+- Copy HTML
+- Dark Mode Support
+
+**Bold Text**
+
+[Visit DevTasks](https://dev-tasks-beta.vercel.app/)
+
+\`\`\`javascript
+console.log("Hello World");
+\`\`\`
+`;
+
+  const [input, setInput] = useState(sampleMarkdown);
+
+  const htmlOutput = marked.parse(input || "");
+
+  const handleSample = () => {
+    setInput(sampleMarkdown);
+  };
+
+  const handleClear = () => {
+    setInput("");
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(htmlOutput);
+      toast.success("HTML copied");
+    } catch {
+      toast.error("Failed to copy");
+    }
+  };
+
+  const buttons = [
+    { label: "Sample", onClick: handleSample },
+    { label: "Clear", onClick: handleClear },
+  ];
+
+  return (
+    <div
+      className={`min-h-[calc(100vh-76px)] md:h-[calc(100vh-76px)] px-4 sm:px-6 py-6 transition-colors duration-300 overflow-y-auto md:overflow-hidden relative flex flex-col justify-center ${
+        dark ? "bg-zinc-950" : "bg-[#F7F7F7]"
+      }`}
+    >
+      <div
+        className={`absolute top-[-10%] right-[-10%] w-[300px] sm:w-[500px] h-[300px] sm:h-[500px] rounded-full blur-[100px] opacity-30 ${
+          dark ? "bg-zinc-800" : "bg-neutral-200"
+        }`}
+      />
+
+      <div
+        className={`absolute bottom-[-10%] left-[-10%] w-[300px] sm:w-[500px] h-[300px] sm:h-[500px] rounded-full blur-[100px] opacity-30 ${
+          dark ? "bg-zinc-900" : "bg-neutral-100"
+        }`}
+      />
+
+      <div
+        className={`relative z-10 w-full max-w-5xl mx-auto rounded-[32px] border shadow-xl flex flex-col max-h-full md:max-h-[85vh] overflow-hidden ${
+          dark ? "bg-zinc-900 border-zinc-800" : "bg-white border-neutral-200"
+        }`}
+      >
+        <div className={`h-2 w-full ${dark ? "bg-white" : "bg-black"}`} />
+
+        <div className="px-5 sm:px-8 pt-6 sm:pt-8 flex items-center gap-3">
+          <Link
+            to="/devutilities"
+            className={`p-2.5 rounded-xl border ${
+              dark
+                ? "bg-zinc-800 border-zinc-700 text-zinc-300"
+                : "bg-white border-neutral-200 text-neutral-600"
+            }`}
+          >
+            ←
+          </Link>
+
+          <h1
+            className={`text-xl sm:text-2xl font-black uppercase ${
+              dark ? "text-white" : "text-black"
+            }`}
+          >
+            Markdown Previewer
+          </h1>
+        </div>
+
+        <div className="w-full md:h-[464px] p-5 sm:p-8 overflow-y-auto">
+          <div className="w-full h-full flex flex-col md:flex-row gap-4">
+            <div className="w-full flex flex-col space-y-2">
+              <div className="flex items-center justify-between h-8">
+                <label
+                  className={`text-xs font-black uppercase tracking-widest ${
+                    dark ? "text-zinc-400" : "text-neutral-500"
+                  }`}
+                >
+                  Markdown Input
+                </label>
+
+                
+              </div>
+
+              <textarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder="# Write markdown here..."
+                className={`md:h-full h-40 px-4 py-3 rounded-2xl border text-sm resize-none ${
+                  dark
+                    ? "bg-zinc-950 border-zinc-800 text-white"
+                    : "bg-neutral-50 border-neutral-300 text-black"
+                }`}
+              />
+
+              <div className="grid grid-cols-2 gap-3">
+                {buttons.map((btn) => (
+                  <button
+                    key={btn.label}
+                    onClick={btn.onClick}
+                    className={`px-4 py-2 rounded-xl border font-bold text-sm ${
+                      dark
+                        ? "border-white text-white hover:bg-white hover:text-black"
+                        : "border-black text-black hover:bg-black hover:text-white"
+                    }`}
+                  >
+                    {btn.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="w-full flex flex-col space-y-2">
+              <label
+                className={`text-xs font-black uppercase tracking-widest ${
+                  dark ? "text-zinc-400" : "text-neutral-500"
+                }`}
+              >
+                HTML Preview
+              </label>
+
+              <div
+                className={`md:h-full h-40 px-4 py-3 rounded-2xl border overflow-auto prose max-w-none ${
+                  dark
+                    ? "bg-zinc-950 border-zinc-800 text-white"
+                    : "bg-neutral-50 border-neutral-300 text-black"
+                }`}
+                dangerouslySetInnerHTML={{ __html: htmlOutput }}
+              />
+
+              <div className="flex justify-end">
+                <button
+                  onClick={handleCopy}
+                  className={`w-40 px-4 py-2 rounded-xl border font-bold text-sm ${
+                    dark
+                      ? "border-white text-white hover:bg-white hover:text-black"
+                      : "border-black text-black hover:bg-black hover:text-white"
+                  }`}
+                >
+                  Copy HTML
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MarkdownPreviewer;

--- a/src/pages/DevUtilities/devutilities/MarkdownPreviewer.jsx
+++ b/src/pages/DevUtilities/devutilities/MarkdownPreviewer.jsx
@@ -3,30 +3,47 @@ import { Link } from "react-router-dom";
 import { toast } from "sonner";
 import { useTheme } from "../../../context/ThemeContext";
 import { marked } from "marked";
+import DOMPurify from "dompurify";
+
+marked.setOptions({
+  gfm: true,
+  breaks: true,
+});
 
 const MarkdownPreviewer = () => {
   const { dark } = useTheme();
 
-  const sampleMarkdown = `# DevTasks Markdown Previewer
+  const sampleMarkdown = `# 🚀 Markdown Previewer
+
+A **live markdown editor** with HTML preview.
 
 ## Features
 
 - Live Preview
 - Copy HTML
+- Download Markdown
 - Dark Mode Support
 
-**Bold Text**
+### Table Example
 
-[Visit DevTasks](https://dev-tasks-beta.vercel.app/)
+| Feature | Status |
+|----------|----------|
+| Preview | ✅ |
+| Copy HTML | ✅ |
+| Download MD | ✅ |
+
+### Code Example
 
 \`\`\`javascript
 console.log("Hello World");
 \`\`\`
+
+[Visit DevTasks](https://dev-tasks-beta.vercel.app/)
 `;
 
   const [input, setInput] = useState(sampleMarkdown);
 
-  const htmlOutput = marked.parse(input || "");
+  const htmlOutput = DOMPurify.sanitize(marked.parse(input || ""));
 
   const handleSample = () => {
     setInput(sampleMarkdown);
@@ -42,6 +59,29 @@ console.log("Hello World");
       toast.success("HTML copied");
     } catch {
       toast.error("Failed to copy");
+    }
+  };
+  const handleDownload = () => {
+    try {
+      const blob = new Blob([input], {
+        type: "text/markdown;charset=utf-8",
+      });
+
+      const url = URL.createObjectURL(blob);
+
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "markdown-preview.md";
+
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+      URL.revokeObjectURL(url);
+
+      toast.success("Markdown downloaded");
+    } catch {
+      toast.error("Download failed");
     }
   };
 
@@ -107,8 +147,6 @@ console.log("Hello World");
                 >
                   Markdown Input
                 </label>
-
-                
               </div>
 
               <textarea
@@ -149,15 +187,25 @@ console.log("Hello World");
               </label>
 
               <div
-                className={`md:h-full h-40 px-4 py-3 rounded-2xl border overflow-auto prose max-w-none ${
+                className={`md:h-full h-40 px-4 py-3 rounded-2xl border overflow-auto prose prose-zinc max-w-none ${
                   dark
-                    ? "bg-zinc-950 border-zinc-800 text-white"
-                    : "bg-neutral-50 border-neutral-300 text-black"
+                    ? "prose-invert bg-zinc-950 border-zinc-800"
+                    : "bg-neutral-50 border-neutral-300"
                 }`}
                 dangerouslySetInnerHTML={{ __html: htmlOutput }}
               />
 
-              <div className="flex justify-end">
+              <div className="flex justify-end gap-3">
+                <button
+                  onClick={handleDownload}
+                  className={`w-40 px-4 py-2 rounded-xl border font-bold text-sm ${
+                    dark
+                      ? "border-white text-white hover:bg-white hover:text-black"
+                      : "border-black text-black hover:bg-black hover:text-white"
+                  }`}
+                >
+                  Download MD
+                </button>
                 <button
                   onClick={handleCopy}
                   className={`w-40 px-4 py-2 rounded-xl border font-bold text-sm ${

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,5 +3,7 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    require("@tailwindcss/typography"),
+  ],
 }


### PR DESCRIPTION
## 📝 Description

This PR adds a new **Markdown Live Previewer** utility to the Dev Utilities Sandbox.

### Changes Made

* Created a new Markdown Live Previewer utility page
* Added the utility to the Dev Utilities dashboard
* Registered the required route
* Implemented a dual-pane layout with a markdown editor and live preview pane
* Added **Sample**, **Clear**, and **Copy HTML** actions
* Integrated markdown parsing using `marked`
* Added support for both light and dark themes
* Implemented a responsive layout for mobile and desktop devices
* Styled rendered markdown content to match the existing monochrome design system

##🔗 Related Issue
Closes #238 

## 📸 Screenshots

Before:

<img width="926" height="464" alt="image" src="https://github.com/user-attachments/assets/64d57ad3-57ab-4f8a-88a1-4fcecf53e84b" />

After:

<img width="935" height="461" alt="image" src="https://github.com/user-attachments/assets/de3e8116-36d2-4b79-82f7-fd2a01916ac2" />
<img width="892" height="427" alt="image" src="https://github.com/user-attachments/assets/d3b9f856-6073-4911-96dc-4fe520689938" />


