### PR TITLE
Add CSS Gradient Generator with presets and color stops

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,7 +21,7 @@ import DataCenterSnippet from "./pages/SnippetVault/snippetvault/DataCenter";
 import HtmlEntityConverter from "./pages/DevUtilities/devutilities/HtmlEntityConverter";
 
 import TextCaseConverter from "./pages/DevUtilities/devutilities/TextCaseConverter";
-//extra added 
+//extra added
 import UserAgentParser from "./pages/DevUtilities/devutilities/UserAgentParser";
 
 // Resource Hub Imports
@@ -49,6 +49,7 @@ import QrCodeGenerator from "./pages/DevUtilities/devutilities/QrCodeGenerator";
 import UrlParserBuilder from "./pages/DevUtilities/devutilities/UrlParserBuilder";
 import SqlFormatter from "./pages/DevUtilities/devutilities/SqlFormatter";
 import JwtEncoder from "./pages/DevUtilities/devutilities/JwtEncoder";
+import CssGradientGenerator from "./pages/DevUtilities/devutilities/CssGradientGenerator";
 
 import { ThemeProvider, useTheme } from "./context/ThemeContext";
 import { CategoryProvider } from "./context/CategoryContext";
@@ -98,7 +99,14 @@ function AppInner({ toggleHUD, hudVisible }) {
   // Temporary global scroll debugger
   useEffect(() => {
     const handleGlobalScroll = (e) => {
-      console.log("[Scroll Debug] scroll target:", e.target, "scrollTop:", e.target.scrollTop, "window.scrollY:", window.scrollY);
+      console.log(
+        "[Scroll Debug] scroll target:",
+        e.target,
+        "scrollTop:",
+        e.target.scrollTop,
+        "window.scrollY:",
+        window.scrollY,
+      );
     };
     window.addEventListener("scroll", handleGlobalScroll, true);
     return () => window.removeEventListener("scroll", handleGlobalScroll, true);
@@ -115,13 +123,31 @@ function AppInner({ toggleHUD, hudVisible }) {
     const timers = [];
     if (savedPosition) {
       const targetScroll = parseInt(savedPosition, 10);
-      console.log(`[Scroll Restoration] Restoring ${location.pathname} to ${targetScroll}`);
+      console.log(
+        `[Scroll Restoration] Restoring ${location.pathname} to ${targetScroll}`,
+      );
       scrollContainer.scrollTop = targetScroll;
-      
-      timers.push(setTimeout(() => { scrollContainer.scrollTop = targetScroll; }, 50));
-      timers.push(setTimeout(() => { scrollContainer.scrollTop = targetScroll; }, 150));
-      timers.push(setTimeout(() => { scrollContainer.scrollTop = targetScroll; }, 300));
-      timers.push(setTimeout(() => { scrollContainer.scrollTop = targetScroll; }, 500));
+
+      timers.push(
+        setTimeout(() => {
+          scrollContainer.scrollTop = targetScroll;
+        }, 50),
+      );
+      timers.push(
+        setTimeout(() => {
+          scrollContainer.scrollTop = targetScroll;
+        }, 150),
+      );
+      timers.push(
+        setTimeout(() => {
+          scrollContainer.scrollTop = targetScroll;
+        }, 300),
+      );
+      timers.push(
+        setTimeout(() => {
+          scrollContainer.scrollTop = targetScroll;
+        }, 500),
+      );
     } else {
       console.log(`[Scroll Restoration] Resetting ${location.pathname} to 0`);
       scrollContainer.scrollTop = 0;
@@ -131,7 +157,9 @@ function AppInner({ toggleHUD, hudVisible }) {
     const safetyTimeout = setTimeout(() => {
       if (isRestoringRef.current) {
         isRestoringRef.current = false;
-        console.log(`[Scroll Restoration] Safety timer enabled scroll saving for ${location.pathname}`);
+        console.log(
+          `[Scroll Restoration] Safety timer enabled scroll saving for ${location.pathname}`,
+        );
       }
     }, 800);
 
@@ -139,14 +167,24 @@ function AppInner({ toggleHUD, hudVisible }) {
     const handleUserInteraction = () => {
       if (isRestoringRef.current) {
         isRestoringRef.current = false;
-        console.log(`[Scroll Restoration] User interaction detected. Scroll saving enabled for ${location.pathname}`);
+        console.log(
+          `[Scroll Restoration] User interaction detected. Scroll saving enabled for ${location.pathname}`,
+        );
       }
     };
 
-    scrollContainer.addEventListener("wheel", handleUserInteraction, { passive: true });
-    scrollContainer.addEventListener("touchmove", handleUserInteraction, { passive: true });
-    scrollContainer.addEventListener("keydown", handleUserInteraction, { passive: true });
-    scrollContainer.addEventListener("mousedown", handleUserInteraction, { passive: true });
+    scrollContainer.addEventListener("wheel", handleUserInteraction, {
+      passive: true,
+    });
+    scrollContainer.addEventListener("touchmove", handleUserInteraction, {
+      passive: true,
+    });
+    scrollContainer.addEventListener("keydown", handleUserInteraction, {
+      passive: true,
+    });
+    scrollContainer.addEventListener("mousedown", handleUserInteraction, {
+      passive: true,
+    });
 
     let saveTimeout;
     const handleScroll = () => {
@@ -161,7 +199,9 @@ function AppInner({ toggleHUD, hudVisible }) {
 
       if (saveTimeout) clearTimeout(saveTimeout);
       saveTimeout = setTimeout(() => {
-        console.log(`[Scroll Restoration] Saving ${location.pathname} position: ${currentScrollTop}`);
+        console.log(
+          `[Scroll Restoration] Saving ${location.pathname} position: ${currentScrollTop}`,
+        );
         sessionStorage.setItem(`scroll_${location.pathname}`, currentScrollTop);
       }, 50);
     };
@@ -181,9 +221,11 @@ function AppInner({ toggleHUD, hudVisible }) {
 
   return (
     <div
-      className={`w-full ${showNavbar ? "h-screen overflow-hidden flex flex-col" : "min-h-screen"
-        } transition-colors duration-300 ${dark ? "bg-zinc-950 text-white" : "bg-[#FDFDFD] text-black"
-        }`}
+      className={`w-full ${
+        showNavbar ? "h-screen overflow-hidden flex flex-col" : "min-h-screen"
+      } transition-colors duration-300 ${
+        dark ? "bg-zinc-950 text-white" : "bg-[#FDFDFD] text-black"
+      }`}
     >
       <SplashScreen />
 
@@ -205,7 +247,10 @@ function AppInner({ toggleHUD, hudVisible }) {
           }
         >
           <Routes>
-            <Route path="/devutilities/user-agent" element={<UserAgentParser />}/>
+            <Route
+              path="/devutilities/user-agent"
+              element={<UserAgentParser />}
+            />
             <Route path="/" element={<Home />} />
             <Route path="/dashboard" element={<Dashboard />} />
 
@@ -255,11 +300,23 @@ function AppInner({ toggleHUD, hudVisible }) {
             <Route path="/devutilities" element={<DevUtilities />} />
             <Route path="/devutilities/regex" element={<RegexTester />} />
             <Route path="/devutilities/json" element={<JsonFormatter />} />
-            <Route path="/devutilities/json-yaml" element={<JsonYamlConverter />} />
-            <Route path="/devutilities/markdown" element={<MarkdownPreviewer />} />
-            <Route path="/devutilities/html-entity" element={<HtmlEntityConverter />} />
+            <Route
+              path="/devutilities/json-yaml"
+              element={<JsonYamlConverter />}
+            />
+            <Route
+              path="/devutilities/markdown"
+              element={<MarkdownPreviewer />}
+            />
+            <Route
+              path="/devutilities/html-entity"
+              element={<HtmlEntityConverter />}
+            />
             <Route path="/devutilities/base64" element={<Base64Url />} />
-            <Route path="/devutilities/timestamp" element={<TimestampConverter />} />
+            <Route
+              path="/devutilities/timestamp"
+              element={<TimestampConverter />}
+            />
             <Route path="/devutilities/uuid" element={<UuidGenerator />} />
             <Route path="/devutilities/jwt" element={<JwtDecoder />} />
             <Route path="/devutilities/jwt-encode" element={<JwtEncoder />} />
@@ -268,17 +325,36 @@ function AppInner({ toggleHUD, hudVisible }) {
             <Route path="/devutilities/color" element={<ColorConverter />} />
             <Route path="/devutilities/code" element={<CodeSandbox />} />
             <Route path="/devutilities/qrcode" element={<QrCodeGenerator />} />
-            <Route path="/devutilities/text-case" element={<TextCaseConverter />} />
-            <Route path="/devutilities/mock-json-generator" element={<MockJsonGenerator />} />
-            <Route path="/devutilities/flexbox-grid-generator" element={<FlexboxGridGenerator />} />
-            <Route path="/devutilities/markdown-table-genertaor" element={<MarkdownTableGenerator />} />
-            <Route path="/devutilities/url-parser" element={<UrlParserBuilder />} />
+            <Route
+              path="/devutilities/text-case"
+              element={<TextCaseConverter />}
+            />
+            <Route
+              path="/devutilities/mock-json-generator"
+              element={<MockJsonGenerator />}
+            />
+            <Route
+              path="/devutilities/flexbox-grid-generator"
+              element={<FlexboxGridGenerator />}
+            />
+            <Route
+              path="/devutilities/markdown-table-genertaor"
+              element={<MarkdownTableGenerator />}
+            />
+            <Route
+              path="/devutilities/url-parser"
+              element={<UrlParserBuilder />}
+            />
             <Route path="/devutilities/sql" element={<SqlFormatter />} />
             <Route
               path="/devutilities/json-schema-validator"
               element={<JsonSchemaValidator />}
             />
             <Route path="/devutilities/cron" element={<CronExpression />} />
+            <Route
+              path="/devutilities/css-gradient"
+              element={<CssGradientGenerator />}
+            />
           </Routes>
         </div>
       </div>

--- a/src/pages/DevUtilities/DevUtilities.jsx
+++ b/src/pages/DevUtilities/DevUtilities.jsx
@@ -129,89 +129,187 @@ const DevUtilities = () => {
             strokeWidth={2}
             d="M13.828 10.172a4 4 0 00-5.656 0l-2 2a4 4 0 105.656 5.656l2-2m-3.656-7.656l2-2a4 4 0 115.656 5.656l-2 2"
           />
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
+          <svg
+            className="w-6 h-6"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
         </svg>
       ),
     },
     {
       title: "UUID Generator",
-      description: "Generate RFC4122-compliant v4 UUIDs offline with formatting options.",
+      description:
+        "Generate RFC4122-compliant v4 UUIDs offline with formatting options.",
       path: "/devutilities/uuid",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
+          />
         </svg>
       ),
     },
     {
       title: "JWT Decoder",
-      description: "Decode and inspect JSON Web Token header and payload data directly in the browser, completely offline.",
+      description:
+        "Decode and inspect JSON Web Token header and payload data directly in the browser, completely offline.",
       path: "/devutilities/jwt",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+          />
         </svg>
       ),
     },
     {
       title: "JWT Encoder",
-      description: "Encode and inspect JSON Web Token header and payload data directly in the browser, completely offline.",
+      description:
+        "Encode and inspect JSON Web Token header and payload data directly in the browser, completely offline.",
       path: "/devutilities/jwt-encode",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+          />
         </svg>
       ),
     },
     {
       title: "Diff Checker",
-      description: "Compare two text blocks and highlight added, removed, and unchanged lines in split or inline view.",
+      description:
+        "Compare two text blocks and highlight added, removed, and unchanged lines in split or inline view.",
       path: "/devutilities/diff",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
+          />
         </svg>
       ),
     },
     {
       title: "Code Sandbox",
-      description: "Instantly test raw HTML/CSS/JS with a live preview. No local environment required.",
+      description:
+        "Instantly test raw HTML/CSS/JS with a live preview. No local environment required.",
       path: "/devutilities/code",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="m16 18 6-6-6-6M8 6l-6 6 6 6" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="m16 18 6-6-6-6M8 6l-6 6 6 6"
+          />
         </svg>
       ),
     },
     {
       title: "Hash Generator",
-      description: "Generate MD5, SHA-1, SHA-256, and SHA-512 cryptographic hashes directly in the browser.",
+      description:
+        "Generate MD5, SHA-1, SHA-256, and SHA-512 cryptographic hashes directly in the browser.",
       path: "/devutilities/hash",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4"
+          />
         </svg>
       ),
     },
     {
       title: "Color Converter & Contrast Checker",
-      description: "Convert HEX, RGB, HSL, and CMYK colors, generate palettes, and verify WCAG contrast offline.",
+      description:
+        "Convert HEX, RGB, HSL, and CMYK colors, generate palettes, and verify WCAG contrast offline.",
       path: "/devutilities/color",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3a9 9 0 100 18 9 9 0 000-18zm0 0c1.5 2 2 4 2 6s-.5 4-2 6c-1.5-2-2-4-2-6s.5-4 2-6zm-6.36 4.64c2.08.83 3.8 2.55 4.64 4.64-2.09-.83-3.81-2.55-4.64-4.64zm12.72 0c-.83 2.09-2.55 3.81-4.64 4.64.83-2.09 2.55-3.81 4.64-4.64z" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 3a9 9 0 100 18 9 9 0 000-18zm0 0c1.5 2 2 4 2 6s-.5 4-2 6c-1.5-2-2-4-2-6s.5-4 2-6zm-6.36 4.64c2.08.83 3.8 2.55 4.64 4.64-2.09-.83-3.81-2.55-4.64-4.64zm12.72 0c-.83 2.09-2.55 3.81-4.64 4.64.83-2.09 2.55-3.81 4.64-4.64z"
+          />
         </svg>
       ),
     },
     {
       title: "QR Code Generator",
-      description: "Create customizable QR codes from text or URLs with color and size options. Fully offline.",
+      description:
+        "Create customizable QR codes from text or URLs with color and size options. Fully offline.",
       path: "/devutilities/qrcode",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 3h7v7H3V3zm11 0h7v7h-7V3zM3 14h7v7H3v-7zm13 0h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3-6h1v1h-1v-1z" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3 3h7v7H3V3zm11 0h7v7h-7V3zM3 14h7v7H3v-7zm13 0h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3-6h1v1h-1v-1z"
+          />
         </svg>
       ),
     },
@@ -278,7 +376,7 @@ const DevUtilities = () => {
         </svg>
       ),
     },
-   
+
     {
       title: "Markdown Previewer",
       description:
@@ -392,18 +490,29 @@ const DevUtilities = () => {
     },
     {
       title: "Flexbox & Grid Generator",
-      description: "Generate flexbox and grid layouts for responsive design. Fully offline.",
+      description:
+        "Generate flexbox and grid layouts for responsive design. Fully offline.",
       path: "/devutilities/flexbox-grid-generator",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 3h7v7H3V3zm11 0h7v7h-7V3zM3 14h7v7H3v-7zm13 0h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3-6h1v1h-1v-1z" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3 3h7v7H3V3zm11 0h7v7h-7V3zM3 14h7v7H3v-7zm13 0h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3-6h1v1h-1v-1z"
+          />
         </svg>
       ),
     },
     {
       title: "User Agent Parser",
       description:
-      "Parse browser user-agent strings and inspect client environment information.",
+        "Parse browser user-agent strings and inspect client environment information.",
       path: "/devutilities/user-agent",
       icon: <FaCode />,
     },
@@ -412,8 +521,39 @@ const DevUtilities = () => {
       description: "Generate and inspect CRON expressions. Fully offline.",
       path: "/devutilities/cron",
       icon: (
-        <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 3h7v7H3V3zm11 0h7v7h-7V3zM3 14h7v7H3v-7zm13 0h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3-6h1v1h-1v-1z" />
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3 3h7v7H3V3zm11 0h7v7h-7V3zM3 14h7v7H3v-7zm13 0h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3 3h1v1h-1v-1zm-3 0h1v1h-1v-1zm3-6h1v1h-1v-1z"
+          />
+        </svg>
+      ),
+    },
+    {
+      title: "CSS Gradient Generator",
+      description:
+        "Create beautiful CSS gradients with live preview and copy-ready code.",
+      path: "/devutilities/css-gradient",
+      icon: (
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M4 4h16v16H4V4zm0 0l16 16"
+          />
         </svg>
       ),
     },
@@ -421,21 +561,20 @@ const DevUtilities = () => {
 
   // There are some duplicate cards, so I'm just leaving this here.
   const uniqueCards = Array.from(
-    new Map(cards.map((card) => [card.path, card])).values()
+    new Map(cards.map((card) => [card.path, card])).values(),
   );
 
   // Splitting both favourite and other cards
   const favoriteSet = new Set(favoritePaths);
-  const favoriteCards = uniqueCards.filter((card) => favoriteSet.has(card.path));
+  const favoriteCards = uniqueCards.filter((card) =>
+    favoriteSet.has(card.path),
+  );
   const otherCards = uniqueCards.filter((card) => !favoriteSet.has(card.path));
   const hasFavorites = favoriteCards.length > 0;
 
   // Mirror favorites back to localStorage whenever the list changes.
   useEffect(() => {
-    localStorage.setItem(
-      FAVORITES_STORAGE_KEY,
-      JSON.stringify(favoritePaths)
-    );
+    localStorage.setItem(FAVORITES_STORAGE_KEY, JSON.stringify(favoritePaths));
   }, [favoritePaths]);
 
   // Toggle a card between favorite and non-favorite states.
@@ -443,7 +582,7 @@ const DevUtilities = () => {
     setFavoritePaths((currentFavorites) =>
       currentFavorites.includes(path)
         ? currentFavorites.filter((item) => item !== path)
-        : [...currentFavorites, path]
+        : [...currentFavorites, path],
     );
   };
 
@@ -462,10 +601,11 @@ const DevUtilities = () => {
           {/* Back navigation and page title area. */}
           <Link
             to="/dashboard"
-            className={`inline-flex items-center gap-2 text-xs font-black uppercase tracking-widest transition-all duration-300 w-fit ${dark
+            className={`inline-flex items-center gap-2 text-xs font-black uppercase tracking-widest transition-all duration-300 w-fit ${
+              dark
                 ? "text-neutral-400 hover:text-white"
                 : "text-neutral-500 hover:text-black"
-              }`}
+            }`}
           >
             <span>← Back to Dashboard</span>
           </Link>
@@ -528,7 +668,8 @@ const DevUtilities = () => {
                   </p>
                 </div>
                 <div className="text-xs font-black uppercase tracking-widest text-zinc-500">
-                  {favoriteCards.length} item{favoriteCards.length === 1 ? "" : "s"}
+                  {favoriteCards.length} item
+                  {favoriteCards.length === 1 ? "" : "s"}
                 </div>
               </div>
 

--- a/src/pages/DevUtilities/devutilities/CssGradientGenerator.jsx
+++ b/src/pages/DevUtilities/devutilities/CssGradientGenerator.jsx
@@ -1,0 +1,196 @@
+import { useState } from "react";
+
+const presets = [
+  {
+    name: "Sunset",
+    type: "linear",
+    angle: 90,
+    stops: [
+      { color: "#ff512f", pos: 0 },
+      { color: "#dd2476", pos: 100 },
+    ],
+  },
+  {
+    name: "Ocean",
+    type: "linear",
+    angle: 120,
+    stops: [
+      { color: "#2193b0", pos: 0 },
+      { color: "#6dd5ed", pos: 100 },
+    ],
+  },
+  {
+    name: "Purple Bliss",
+    type: "radial",
+    angle: 0,
+    stops: [
+      { color: "#360033", pos: 0 },
+      { color: "#0b8793", pos: 100 },
+    ],
+  },
+];
+
+export default function CssGradientGenerator() {
+  const [type, setType] = useState("linear");
+  const [angle, setAngle] = useState(90);
+  const [stops, setStops] = useState([
+    { color: "#ff0000", pos: 0 },
+    { color: "#0000ff", pos: 100 },
+  ]);
+
+  const gradient = () => {
+    const sorted = [...stops].sort((a, b) => a.pos - b.pos);
+    const stopStr = sorted.map(s => `${s.color} ${s.pos}%`).join(", ");
+
+    if (type === "radial") {
+      return `radial-gradient(circle, ${stopStr})`;
+    }
+    return `linear-gradient(${angle}deg, ${stopStr})`;
+  };
+
+  const addStop = () => {
+    setStops([...stops, { color: "#ffffff", pos: 50 }]);
+  };
+
+  const updateStop = (i, key, value) => {
+    const copy = [...stops];
+    copy[i][key] = value;
+    setStops(copy);
+  };
+
+  const removeStop = (i) => {
+    setStops(stops.filter((_, idx) => idx !== i));
+  };
+
+  const randomize = () => {
+    const randColor = () =>
+      "#" + Math.floor(Math.random() * 16777215).toString(16);
+
+    setStops([
+      { color: randColor(), pos: 0 },
+      { color: randColor(), pos: 50 },
+      { color: randColor(), pos: 100 },
+    ]);
+  };
+
+  const copyCSS = () => {
+    navigator.clipboard.writeText(
+      `background: ${gradient()};`
+    );
+  };
+
+  return (
+    <div className="p-6 text-white space-y-6">
+
+      {/* HEADER */}
+      <h1 className="text-2xl font-black uppercase">
+        CSS Gradient Generator
+      </h1>
+
+      {/* CONTROLS */}
+      <div className="flex gap-4 flex-wrap">
+
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          className="text-black px-2 py-1"
+        >
+          <option value="linear">Linear</option>
+          <option value="radial">Radial</option>
+        </select>
+
+        {type === "linear" && (
+          <input
+            type="range"
+            min="0"
+            max="360"
+            value={angle}
+            onChange={(e) => setAngle(e.target.value)}
+          />
+        )}
+
+        <button onClick={addStop} className="bg-blue-600 px-3 py-1">
+          Add Stop
+        </button>
+
+        <button onClick={randomize} className="bg-purple-600 px-3 py-1">
+          Random
+        </button>
+
+        <button onClick={copyCSS} className="bg-green-600 px-3 py-1">
+          Copy CSS
+        </button>
+      </div>
+
+      {/* COLOR STOPS */}
+      <div className="space-y-2">
+        {stops.map((s, i) => (
+          <div key={i} className="flex gap-2 items-center">
+
+            <input
+              type="color"
+              value={s.color}
+              onChange={(e) => updateStop(i, "color", e.target.value)}
+            />
+
+            <input
+              type="number"
+              value={s.pos}
+              onChange={(e) => updateStop(i, "pos", Number(e.target.value))}
+              className="text-black w-20"
+            />
+
+            <button
+              onClick={() => removeStop(i)}
+              className="bg-red-600 px-2"
+            >
+              X
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* PREVIEW */}
+      <div
+        className="h-48 rounded-xl border"
+        style={{ background: gradient() }}
+      />
+
+      {/* OUTPUT */}
+      <div className="bg-black p-3 rounded text-green-400">
+        {`background: ${gradient()};`}
+      </div>
+
+      {/* PRESETS */}
+      <div className="space-y-2">
+        <h2 className="font-bold">Presets</h2>
+
+        <div className="grid grid-cols-2 gap-2">
+          {presets.map((p, i) => (
+            <button
+              key={i}
+              onClick={() => {
+                setType(p.type);
+                setAngle(p.angle);
+                setStops(p.stops);
+              }}
+              className="p-2 border rounded"
+              style={{
+                background:
+                  p.type === "linear"
+                    ? `linear-gradient(${p.angle}deg, ${p.stops
+                        .map(s => `${s.color} ${s.pos}%`)
+                        .join(", ")})`
+                    : `radial-gradient(circle, ${p.stops
+                        .map(s => `${s.color} ${s.pos}%`)
+                        .join(", ")})`,
+              }}
+            >
+              {p.name}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📝 Description
Added CSS Gradient Generator utility with live preview, color controls, angle adjustment, preset support, and copy-to-clipboard CSS output. The tool is fully client-side and follows the existing monochrome design system of the project.

## 🔗 Related Issue
Closes #282

## 🎯 Type of Change
- [x] `feat`: New feature

## ✅ Checklist
- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [x] Tested locally on the latest version 🧪
- [ ] Added screenshots (if UI was changed) 📸

## 📸 Screenshots (if applicable)
| Before | After |
| --- | --- |
| N/A | N/A |