### PR TITLE
feat: add text list cleaner utility

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -79,6 +79,7 @@ import UrlParserBuilder from "./pages/DevUtilities/devutilities/UrlParserBuilder
 import UserAgentParser from "./pages/DevUtilities/devutilities/UserAgentParser";
 import UuidGenerator from "./pages/DevUtilities/devutilities/UuidGenerator";
 import WordCounter from "./pages/DevUtilities/devutilities/WordCounter";
+import TextListCleaner from "./pages/DevUtilities/devutilities/TextListCleaner";
 import GitCommandBuilder from "./pages/DevUtilities/devutilities/GitCommandBuilder";
 import ImageOptimizer from "./pages/DevUtilities/devutilities/ImageOptimizer";
 import ColorPaletteExtractor from "./pages/DevUtilities/devutilities/ColorPaletteExtractor";
@@ -544,6 +545,10 @@ function AppInner({ toggleHUD, hudVisible }) {
               <Route
                 path="/devutilities/word-counter"
                 element={<WordCounter />}
+              />
+              <Route
+                path="/devutilities/text-list-cleaner"
+                element={<TextListCleaner />}
               />
               <Route
                 path="/devutilities/sql-converter"

--- a/src/config/sidebarSections.js
+++ b/src/config/sidebarSections.js
@@ -392,6 +392,13 @@ const SIDEBAR_SECTIONS = [
         description: "Character & word count tool",
         path: "/devutilities/word-counter",
       },
+     
+      {
+        label: "Text List Cleaner",
+        description: "Sort, clean, and remove duplicate text lines",
+        path: "/devutilities/text-list-cleaner",
+      },
+
       {
         label: "SQL Schema Converter",
         description:

--- a/src/pages/DevUtilities/DevUtilities.jsx
+++ b/src/pages/DevUtilities/DevUtilities.jsx
@@ -1173,6 +1173,32 @@ const DevUtilities = () => {
         </svg>
       ),
     },
+    
+    {
+      title: "Text List Cleaner",
+      description:
+        "Sort lines, remove duplicates, trim whitespace, and remove empty lines completely offline.",
+      keywords:
+        "text list sort lines duplicates deduplicate clean trim whitespace",
+      path: "/devutilities/text-list-cleaner",
+      icon: (
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 6h12M8 12h12M8 18h12M4 6h.01M4 12h.01M4 18h.01"
+          />
+        </svg>
+      ),
+    },
+    
     {
       title: "Git Command Builder",
       description:

--- a/src/pages/DevUtilities/devutilities/TextListCleaner.jsx
+++ b/src/pages/DevUtilities/devutilities/TextListCleaner.jsx
@@ -1,0 +1,427 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useTheme } from "../../../context/ThemeContext";
+
+const SAMPLE_TEXT = `  banana
+
+Apple
+banana
+orange
+apple
+  grape
+orange  `;
+
+const TextListCleaner = () => {
+  const { dark } = useTheme();
+
+  const [text, setText] = useState("");
+  const [copyStatus, setCopyStatus] = useState("");
+
+  const lines = useMemo(() => {
+    if (text === "") {
+      return [];
+    }
+
+    return text.split(/\r?\n/);
+  }, [text]);
+
+  const nonEmptyLines = useMemo(
+    () => lines.filter((line) => line.trim() !== ""),
+    [lines],
+  );
+
+  const uniqueLineCount = useMemo(() => {
+    const uniqueLines = new Set(
+      nonEmptyLines.map((line) => line.trim().toLowerCase()),
+    );
+
+    return uniqueLines.size;
+  }, [nonEmptyLines]);
+
+  const updateText = (newText) => {
+    setText(newText);
+    setCopyStatus("");
+  };
+
+  const transformLines = (transformFunction) => {
+    const currentLines = text.split(/\r?\n/);
+    const updatedLines = transformFunction(currentLines);
+
+    updateText(updatedLines.join("\n"));
+  };
+
+  const sortLines = (direction) => {
+    transformLines((currentLines) =>
+      [...currentLines].sort((firstLine, secondLine) => {
+        const comparison = firstLine
+          .trim()
+          .localeCompare(secondLine.trim(), undefined, {
+            sensitivity: "base",
+          });
+
+        return direction === "asc" ? comparison : -comparison;
+      }),
+    );
+  };
+
+  const removeDuplicates = () => {
+    transformLines((currentLines) => {
+      const seenLines = new Set();
+
+      return currentLines.filter((line) => {
+        const normalizedLine = line.trim().toLowerCase();
+
+        if (seenLines.has(normalizedLine)) {
+          return false;
+        }
+
+        seenLines.add(normalizedLine);
+        return true;
+      });
+    });
+  };
+
+  const trimWhitespace = () => {
+    transformLines((currentLines) =>
+      currentLines.map((line) => line.trim()),
+    );
+  };
+
+  const removeEmptyLines = () => {
+    transformLines((currentLines) =>
+      currentLines.filter((line) => line.trim() !== ""),
+    );
+  };
+
+  const cleanAll = () => {
+    transformLines((currentLines) => {
+      const seenLines = new Set();
+
+      return currentLines
+        .map((line) => line.trim())
+        .filter((line) => line !== "")
+        .filter((line) => {
+          const normalizedLine = line.toLowerCase();
+
+          if (seenLines.has(normalizedLine)) {
+            return false;
+          }
+
+          seenLines.add(normalizedLine);
+          return true;
+        });
+    });
+  };
+
+  const loadSample = () => {
+    updateText(SAMPLE_TEXT);
+  };
+
+  const clearText = () => {
+    updateText("");
+  };
+
+  const copyText = async () => {
+    if (!text) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyStatus("Copied!");
+    } catch {
+      setCopyStatus("Copy failed");
+    }
+  };
+
+  const actionButtons = [
+    {
+      label: "Sort A-Z",
+      onClick: () => sortLines("asc"),
+    },
+    {
+      label: "Sort Z-A",
+      onClick: () => sortLines("desc"),
+    },
+    {
+      label: "Remove Duplicates",
+      onClick: removeDuplicates,
+    },
+    {
+      label: "Trim Whitespace",
+      onClick: trimWhitespace,
+    },
+    {
+      label: "Remove Empty Lines",
+      onClick: removeEmptyLines,
+    },
+    {
+      label: "Clean All",
+      onClick: cleanAll,
+    },
+  ];
+
+  const actionButtonClass = `
+    w-full rounded-xl border px-4 py-3
+    text-sm font-bold
+    transition-all duration-300
+    active:scale-95
+    disabled:cursor-not-allowed disabled:opacity-40
+    ${
+      dark
+        ? "border-zinc-700 bg-zinc-950 text-white hover:border-white hover:bg-white hover:text-black"
+        : "border-zinc-300 bg-white text-black hover:border-black hover:bg-black hover:text-white"
+    }
+  `;
+
+  return (
+    <div
+      className={`min-h-screen transition-colors duration-300 ${
+        dark
+          ? "bg-[#090A0F] text-zinc-100"
+          : "bg-[#F8F9FA] text-zinc-900"
+      }`}
+    >
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <Link
+          to="/devutilities"
+          className={`mb-6 inline-flex items-center text-sm font-semibold transition-colors ${
+            dark
+              ? "text-zinc-400 hover:text-white"
+              : "text-zinc-600 hover:text-black"
+          }`}
+        >
+          ← Back to Dev Utilities
+        </Link>
+
+        <div className="mb-8">
+          <p
+            className={`mb-2 text-xs font-bold uppercase tracking-[0.2em] ${
+              dark ? "text-zinc-500" : "text-zinc-500"
+            }`}
+          >
+            Developer Utility
+          </p>
+
+          <h1 className="text-3xl font-black tracking-tight sm:text-4xl">
+            Text List Cleaner
+          </h1>
+
+          <p
+            className={`mt-3 max-w-3xl text-sm leading-6 sm:text-base ${
+              dark ? "text-zinc-400" : "text-zinc-600"
+            }`}
+          >
+            Sort text lines, remove duplicates, trim whitespace, and remove
+            empty lines directly in your browser.
+          </p>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[1fr_280px]">
+          <section
+            className={`rounded-3xl border p-5 transition-colors sm:p-6 ${
+              dark
+                ? "border-zinc-800 bg-zinc-900/50"
+                : "border-zinc-200 bg-white"
+            }`}
+          >
+            <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <label
+                htmlFor="text-list-input"
+                className="text-sm font-bold"
+              >
+                List Input
+              </label>
+
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={loadSample}
+                  className={`rounded-lg border px-3 py-2 text-xs font-bold transition-all active:scale-95 ${
+                    dark
+                      ? "border-zinc-700 text-zinc-300 hover:border-white hover:text-white"
+                      : "border-zinc-300 text-zinc-700 hover:border-black hover:text-black"
+                  }`}
+                >
+                  Load Sample
+                </button>
+
+                <button
+                  type="button"
+                  onClick={clearText}
+                  disabled={!text}
+                  className={`rounded-lg border px-3 py-2 text-xs font-bold transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 ${
+                    dark
+                      ? "border-zinc-700 text-zinc-300 hover:border-white hover:text-white"
+                      : "border-zinc-300 text-zinc-700 hover:border-black hover:text-black"
+                  }`}
+                >
+                  Clear
+                </button>
+              </div>
+            </div>
+
+            <textarea
+              id="text-list-input"
+              value={text}
+              onChange={(event) => updateText(event.target.value)}
+              placeholder={`Enter one item per line...
+
+Example:
+Apple
+Banana
+Apple
+Orange`}
+              spellCheck="false"
+              className={`min-h-[360px] w-full resize-y rounded-2xl border px-4 py-4 font-mono text-sm outline-none transition-all duration-300 ${
+                dark
+                  ? "border-zinc-800 bg-zinc-950 text-white placeholder-zinc-700 focus:border-white focus:ring-1 focus:ring-white"
+                  : "border-zinc-300 bg-neutral-50 text-black placeholder-zinc-400 focus:border-black focus:ring-1 focus:ring-black"
+              }`}
+            />
+
+            <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+              {actionButtons.map((button) => (
+                <button
+                  key={button.label}
+                  type="button"
+                  onClick={button.onClick}
+                  disabled={!text}
+                  className={actionButtonClass}
+                >
+                  {button.label}
+                </button>
+              ))}
+            </div>
+
+            <div
+              className={`mt-5 flex flex-col gap-3 border-t pt-5 sm:flex-row sm:items-center sm:justify-between ${
+                dark ? "border-zinc-800" : "border-zinc-200"
+              }`}
+            >
+              <p
+                className={`text-xs ${
+                  dark ? "text-zinc-500" : "text-zinc-500"
+                }`}
+              >
+                All processing happens locally in your browser.
+              </p>
+
+              <div className="flex items-center gap-3">
+                <span
+                  aria-live="polite"
+                  className={`text-xs font-bold ${
+                    copyStatus === "Copied!"
+                      ? dark
+                        ? "text-white"
+                        : "text-black"
+                      : "text-zinc-500"
+                  }`}
+                >
+                  {copyStatus}
+                </span>
+
+                <button
+                  type="button"
+                  onClick={copyText}
+                  disabled={!text}
+                  className={`rounded-xl px-5 py-3 text-sm font-bold transition-all duration-300 active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 ${
+                    dark
+                      ? "bg-white text-black hover:bg-zinc-200"
+                      : "bg-black text-white hover:bg-zinc-800"
+                  }`}
+                >
+                  Copy Text
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <aside className="flex flex-col gap-6">
+            <div
+              className={`rounded-3xl border p-5 ${
+                dark
+                  ? "border-zinc-800 bg-zinc-900/50"
+                  : "border-zinc-200 bg-white"
+              }`}
+            >
+              <h2 className="mb-5 text-lg font-black">List Statistics</h2>
+
+              <div className="space-y-4">
+                <div
+                  className={`flex items-center justify-between border-b pb-3 ${
+                    dark ? "border-zinc-800" : "border-zinc-200"
+                  }`}
+                >
+                  <span
+                    className={`text-sm ${
+                      dark ? "text-zinc-400" : "text-zinc-600"
+                    }`}
+                  >
+                    Total Lines
+                  </span>
+
+                  <span className="text-lg font-black">{lines.length}</span>
+                </div>
+
+                <div
+                  className={`flex items-center justify-between border-b pb-3 ${
+                    dark ? "border-zinc-800" : "border-zinc-200"
+                  }`}
+                >
+                  <span
+                    className={`text-sm ${
+                      dark ? "text-zinc-400" : "text-zinc-600"
+                    }`}
+                  >
+                    Non-Empty
+                  </span>
+
+                  <span className="text-lg font-black">
+                    {nonEmptyLines.length}
+                  </span>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <span
+                    className={`text-sm ${
+                      dark ? "text-zinc-400" : "text-zinc-600"
+                    }`}
+                  >
+                    Unique Lines
+                  </span>
+
+                  <span className="text-lg font-black">
+                    {uniqueLineCount}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div
+              className={`rounded-3xl border p-5 ${
+                dark
+                  ? "border-zinc-800 bg-zinc-900/50"
+                  : "border-zinc-200 bg-white"
+              }`}
+            >
+              <h2 className="mb-3 text-lg font-black">How It Works</h2>
+
+              <p
+                className={`text-sm leading-6 ${
+                  dark ? "text-zinc-400" : "text-zinc-600"
+                }`}
+              >
+                Enter one item per line, then choose an action. The Clean All
+                option trims whitespace, removes blank lines, and removes
+                duplicates while keeping the first occurrence.
+              </p>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TextListCleaner;


### PR DESCRIPTION
## 📝 Description

This pull request adds a new **Text List Cleaner** utility to the Dev Utilities Sandbox.

The new tool allows users to:

- Sort lines from A-Z or Z-A
- Remove duplicate lines
- Trim extra whitespace
- Remove empty lines
- Clean a list with one action
- Copy the cleaned text
- View total, non-empty, and unique line counts

The feature works completely in the browser and does not require any additional dependencies or external APIs. It was also added to the Dev Utilities dashboard, sidebar navigation, and application routing.

## 🔗 Related Issue

Closes #193

## 🎯 Type of Change

- [ ] `fix`: Bug fix
- [x] `feat`: New feature
- [ ] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist

- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [x] Added screenshots (if UI was changed) 📸
- [x] Tested locally on the latest version 🧪

## 📸 Screenshots

<img width="2490" height="1264" alt="Screenshot 2026-07-11 185023" src="https://github.com/user-attachments/assets/c4c3c10d-0ba6-43f4-8929-edfc7b652750" />
<img width="2480" height="1277" alt="Screenshot 2026-07-11 184910" src="https://github.com/user-attachments/assets/bc034667-7b32-4fc3-8ba0-b33450c2d212" />
<img width="2513" height="1277" alt="Screenshot 2026-07-11 184930" src="https://github.com/user-attachments/assets/23f400f8-0ae1-4f75-b48c-edca3df232df" />
<img width="2468" height="1275" alt="Screenshot 2026-07-11 184945" src="https://github.com/user-attachments/assets/e1509ea0-8537-4c9a-917b-de945811635c" />
<img width="2496" height="1281" alt="Screenshot 2026-07-11 185001" src="https://github.com/user-attachments/assets/fd75fdf1-c498-4858-aa81-b831d884b8f9" />

### Text List Cleaner
