### PR TITLE
ci: add README Review action for contribution quality

### DIFF
--- a/.github/workflows/readme-review.yml
+++ b/.github/workflows/readme-review.yml
@@ -1,0 +1,15 @@
+name: README Review
+on:
+  pull_request:
+    paths:
+      - 'README.md'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: iteebz/readme-review@v1


### PR DESCRIPTION
Hey! I noticed DevTasks actively accepts README contributions and wanted to add a small quality check.

This adds [README Review](https://github.com/iteebz/readme-review) — a GitHub Action that scores README quality (0–100) on any PR that touches `README.md`. It posts a comment with a letter grade and a shields.io badge contributors can embed.

No API keys needed, pure heuristic scoring. Fires only on PRs that actually change the README, so it stays out of the way otherwise.

The badge output looks like: `README: A (90/100)` — gives contributors a concrete target when improving docs.

**See your grade first:** [grade shamilahmdt/devtasks's README instantly](https://iteebz.github.io/readme-scorecard/?repo=shamilahmdt/devtasks) — same heuristic, no install, in your browser. If it's useful, this action runs it on every PR.