### PR TITLE
feat: add SVG to Data URI converter

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -72,6 +72,7 @@ import SqlSchemaConverter from "./pages/DevUtilities/devutilities/SqlSchemaConve
 import StringInspector from "./pages/DevUtilities/devutilities/StringInspector";
 import SubnetCalculator from "./pages/DevUtilities/devutilities/SubnetCalculator";
 import SvgOptimizer from "./pages/DevUtilities/devutilities/SvgOptimizer";
+import SvgToDataUri from "./pages/DevUtilities/devutilities/SvgToDataUri";
 import SlugGenerator from "./pages/DevUtilities/devutilities/SlugGenerator";
 import TextCaseConverter from "./pages/DevUtilities/devutilities/TextCaseConverter";
 import TimestampConverter from "./pages/DevUtilities/devutilities/TimestampConverter";
@@ -535,6 +536,10 @@ function AppInner({ toggleHUD, hudVisible }) {
               <Route
                 path="/devutilities/svg-optimizer"
                 element={<SvgOptimizer />}
+              />
+              <Route
+                path="/devutilities/svg-to-data-uri"
+                element={<SvgToDataUri />}
               />
               <Route
                 path="/devutilities/password-generator"

--- a/src/config/sidebarSections.js
+++ b/src/config/sidebarSections.js
@@ -363,6 +363,12 @@ const SIDEBAR_SECTIONS = [
         path: "/devutilities/svg-optimizer",
       },
       {
+        label: "SVG to Data URI Converter",
+        description:
+          "Convert raw SVG markup into optimized CSS background-image statements and data URIs.",
+        path: "/devutilities/svg-to-data-uri",
+      },
+      {
         label: "Password Generator",
         description:
           "Generate secure passwords and analyze entropy, strength, and crack times.",

--- a/src/pages/DevUtilities/DevUtilities.jsx
+++ b/src/pages/DevUtilities/DevUtilities.jsx
@@ -116,6 +116,28 @@ const DevUtilities = () => {
       ),
     },
     {
+      title: "SVG to Data URI Converter",
+      description:
+        "Convert raw SVG markup into optimized CSS background-image statements and data URIs.",
+      keywords: "svg uri css base64 image encode",
+      path: "/devutilities/svg-to-data-uri",
+      icon: (
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 9l-3 3 3 3m8-6l3 3-3 3m-3-9l-2 12"
+          />
+        </svg>
+      ),
+    },
+    {
       title: "Morse Code Converter",
       description:
         "Convert text to Morse code and decode Morse code back to text.",

--- a/src/pages/DevUtilities/devutilities/SvgToDataUri.jsx
+++ b/src/pages/DevUtilities/devutilities/SvgToDataUri.jsx
@@ -1,0 +1,281 @@
+import { useMemo, useState } from "react";
+import { FaCopy, FaEye, FaFileCode, FaTrash } from "react-icons/fa";
+import { Link } from "react-router-dom";
+import { toast } from "sonner";
+import { useTheme } from "../../../context/ThemeContext";
+import { createSvgOutputs } from "./svgDataUri";
+
+const SAMPLE_SVG = `<svg width="160" height="160" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="160" rx="32" fill="#18181b"/>
+  <path d="M48 82l20 20 44-48" fill="none" stroke="#ffffff" stroke-width="12" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>`;
+
+function validateSvg(svg) {
+  if (!svg.trim()) {
+    return { valid: false, message: "Paste SVG markup to generate a preview." };
+  }
+
+  try {
+    const document = new DOMParser().parseFromString(svg, "image/svg+xml");
+    const parserError = document.querySelector("parsererror");
+
+    if (parserError || document.documentElement.localName !== "svg") {
+      return { valid: false, message: "The SVG markup could not be parsed." };
+    }
+
+    return { valid: true, message: "SVG parsed successfully." };
+  } catch {
+    return { valid: false, message: "The SVG markup could not be parsed." };
+  }
+}
+
+function SvgToDataUri() {
+  const { dark } = useTheme();
+  const [svg, setSvg] = useState("");
+  const [quoteStyle, setQuoteStyle] = useState("double");
+
+  const outputs = useMemo(
+    () => createSvgOutputs(svg, quoteStyle),
+    [svg, quoteStyle],
+  );
+  const validation = useMemo(() => validateSvg(svg), [svg]);
+
+  const theme = {
+    wrapper: dark
+      ? "bg-[#090A0F] text-zinc-100"
+      : "bg-[#F8F9FA] text-zinc-900",
+    card: dark
+      ? "bg-zinc-900/50 border-zinc-800/85 shadow-lg"
+      : "bg-white border-zinc-200/85 shadow-sm",
+    input: dark
+      ? "bg-zinc-950/70 border-zinc-800 text-zinc-100 placeholder-zinc-600 focus:border-zinc-600"
+      : "bg-zinc-50 border-zinc-200 text-zinc-900 placeholder-zinc-400 focus:border-zinc-400",
+    secondary: dark
+      ? "bg-zinc-950/50 text-zinc-300 border-zinc-800 hover:bg-zinc-800 hover:text-white"
+      : "bg-white text-zinc-700 border-zinc-200 hover:bg-zinc-50 hover:text-zinc-950",
+    active: dark
+      ? "bg-white text-zinc-950 border-white"
+      : "bg-zinc-900 text-white border-zinc-900",
+    inactive: dark
+      ? "bg-zinc-950/50 text-zinc-400 border-zinc-800 hover:text-white"
+      : "bg-white text-zinc-600 border-zinc-200 hover:text-zinc-950",
+    subtext: dark ? "text-zinc-400" : "text-zinc-500",
+    preview: dark
+      ? "bg-zinc-950/70 border-zinc-800"
+      : "bg-zinc-50 border-zinc-200",
+  };
+
+  const copy = async (value, label) => {
+    if (!value) return;
+
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success(`${label} copied to clipboard`);
+    } catch {
+      toast.error("Failed to copy to clipboard");
+    }
+  };
+
+  const outputFields = [
+    ["CSS Background Image", outputs.css],
+    ["HTML Image Tag", outputs.html],
+    ["Base64 Data URI", outputs.base64],
+    ["Raw URL-encoded Data URI", outputs.raw],
+  ];
+
+  return (
+    <div
+      className={`min-h-screen px-4 py-10 transition-colors duration-300 sm:px-6 ${theme.wrapper}`}
+    >
+      <title>SVG to Data URI Converter — DevTasks</title>
+      <meta
+        name="description"
+        content="Convert raw SVG markup into optimized CSS background-image statements and data URIs offline."
+      />
+
+      <div className="mx-auto max-w-7xl">
+        <header className="mb-8 flex items-center gap-4">
+          <Link
+            to="/devutilities"
+            className={`flex shrink-0 items-center justify-center rounded-xl border p-2.5 transition-all active:scale-95 ${theme.secondary}`}
+            title="Back to Dev Utilities"
+            aria-label="Back to Dev Utilities"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2.5}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </Link>
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">
+              SVG to Data URI Converter
+            </h1>
+            <p className={`mt-1 text-sm ${theme.subtext}`}>
+              Create compact CSS, HTML, and Base64 SVG snippets entirely in
+              your browser.
+            </p>
+          </div>
+        </header>
+
+        <div className="grid grid-cols-1 items-start gap-8 lg:grid-cols-2">
+          <section className={`rounded-3xl border p-6 sm:p-8 ${theme.card}`}>
+            <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+              <div className="flex items-center gap-2.5">
+                <FaFileCode className="text-zinc-500" />
+                <h2 className="text-lg font-bold">SVG Input</h2>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSvg(SAMPLE_SVG);
+                    toast.success("Sample SVG loaded");
+                  }}
+                  className={`cursor-pointer rounded-lg border px-3 py-1.5 text-xs font-semibold transition-colors ${theme.secondary}`}
+                >
+                  Load sample
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setSvg("")}
+                  disabled={!svg}
+                  className={`cursor-pointer rounded-lg border px-3 py-1.5 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${theme.secondary}`}
+                >
+                  <FaTrash className="mr-1 inline" /> Clear
+                </button>
+              </div>
+            </div>
+
+            <label
+              htmlFor="svg-input"
+              className={`mb-2 block text-xs font-bold uppercase tracking-wider ${theme.subtext}`}
+            >
+              Raw SVG markup
+            </label>
+            <textarea
+              id="svg-input"
+              rows={16}
+              value={svg}
+              onChange={(event) => setSvg(event.target.value)}
+              placeholder={'<svg viewBox="0 0 24 24">...</svg>'}
+              spellCheck={false}
+              className={`w-full resize-y rounded-2xl border p-4 font-mono text-xs leading-relaxed outline-none transition-colors ${theme.input}`}
+            />
+
+            <fieldset className="mt-6">
+              <legend
+                className={`mb-3 text-xs font-bold uppercase tracking-wider ${theme.subtext}`}
+              >
+                CSS outer quote style
+              </legend>
+              <div className="grid grid-cols-2 gap-3">
+                {[
+                  ["double", 'Double quotes (\"…\")'],
+                  ["single", "Single quotes ('…')"],
+                ].map(([value, label]) => (
+                  <button
+                    type="button"
+                    key={value}
+                    onClick={() => setQuoteStyle(value)}
+                    aria-pressed={quoteStyle === value}
+                    className={`cursor-pointer rounded-xl border px-4 py-3 text-xs font-bold transition-colors ${
+                      quoteStyle === value ? theme.active : theme.inactive
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+              <p className={`mt-3 text-xs leading-relaxed ${theme.subtext}`}>
+                Conflicting SVG quotes are encoded to preserve the selected
+                CSS wrapper.
+              </p>
+            </fieldset>
+          </section>
+
+          <section className="space-y-6">
+            <div className={`rounded-3xl border p-6 sm:p-8 ${theme.card}`}>
+              <div className="mb-4 flex items-center gap-2.5">
+                <FaEye className="text-zinc-500" />
+                <h2 className="text-lg font-bold">Live Preview</h2>
+              </div>
+              <div
+                className={`flex min-h-48 items-center justify-center rounded-2xl border bg-[linear-gradient(45deg,rgba(127,127,127,.08)_25%,transparent_25%),linear-gradient(-45deg,rgba(127,127,127,.08)_25%,transparent_25%),linear-gradient(45deg,transparent_75%,rgba(127,127,127,.08)_75%),linear-gradient(-45deg,transparent_75%,rgba(127,127,127,.08)_75%)] bg-[length:20px_20px] ${theme.preview}`}
+              >
+                {validation.valid ? (
+                  <div
+                    role="img"
+                    aria-label="Converted SVG preview"
+                    className="h-32 w-32 bg-contain bg-center bg-no-repeat"
+                    style={{ backgroundImage: `url("${outputs.preview}")` }}
+                  />
+                ) : (
+                  <p className={`px-6 text-center text-sm ${theme.subtext}`}>
+                    {validation.message}
+                  </p>
+                )}
+              </div>
+              {svg && (
+                <p
+                  role="status"
+                  aria-live="polite"
+                  className={`mt-3 text-xs ${
+                    validation.valid ? "text-emerald-500" : "text-red-500"
+                  }`}
+                >
+                  {validation.message}
+                </p>
+              )}
+            </div>
+
+            <div className={`rounded-3xl border p-6 sm:p-8 ${theme.card}`}>
+              <h2 className="mb-5 text-lg font-bold">Generated Outputs</h2>
+              <div className="space-y-5">
+                {outputFields.map(([label, value]) => (
+                  <div key={label}>
+                    <div className="mb-2 flex items-center justify-between gap-3">
+                      <label
+                        className={`text-xs font-bold uppercase tracking-wider ${theme.subtext}`}
+                      >
+                        {label}
+                      </label>
+                      <button
+                        type="button"
+                        onClick={() => copy(value, label)}
+                        disabled={!value}
+                        className={`flex cursor-pointer items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${theme.secondary}`}
+                        aria-label={`Copy ${label}`}
+                      >
+                        <FaCopy /> Copy
+                      </button>
+                    </div>
+                    <textarea
+                      value={value}
+                      readOnly
+                      rows={label === "CSS Background Image" ? 3 : 2}
+                      placeholder="Output appears as you type..."
+                      spellCheck={false}
+                      aria-label={label}
+                      className={`w-full resize-y rounded-xl border p-3 font-mono text-xs leading-relaxed outline-none ${theme.input}`}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SvgToDataUri;

--- a/src/pages/DevUtilities/devutilities/svgDataUri.js
+++ b/src/pages/DevUtilities/devutilities/svgDataUri.js
@@ -1,0 +1,47 @@
+export const SVG_DATA_URI_PREFIX = "data:image/svg+xml;utf8,";
+
+export function encodeSvgForDataUri(svg, quoteStyle = "double") {
+  const wrapperQuote = quoteStyle === "single" ? /'/g : /"/g;
+  const encodedQuote = quoteStyle === "single" ? "%27" : "%22";
+
+  return svg
+    .trim()
+    .replace(/%/g, "%25")
+    .replace(/#/g, "%23")
+    .replace(/&/g, "%26")
+    .replace(/</g, "%3C")
+    .replace(/>/g, "%3E")
+    .replace(wrapperQuote, encodedQuote)
+    .replace(/\r?\n|\r/g, " ");
+}
+
+export function createSvgOutputs(svg, quoteStyle = "double") {
+  if (!svg.trim()) {
+    return {
+      css: "",
+      html: "",
+      base64: "",
+      raw: "",
+      preview: "",
+    };
+  }
+
+  const quote = quoteStyle === "single" ? "'" : '"';
+  const encoded = encodeSvgForDataUri(svg, quoteStyle);
+  const htmlEncoded = encodeSvgForDataUri(svg, "double");
+  const raw = `${SVG_DATA_URI_PREFIX}${encoded}`;
+  const preview = `${SVG_DATA_URI_PREFIX}${htmlEncoded}`;
+  const encoder =
+    typeof window === "undefined" ? globalThis.btoa : window.btoa.bind(window);
+  const base64 = `data:image/svg+xml;base64,${encoder(
+    unescape(encodeURIComponent(svg.trim())),
+  )}`;
+
+  return {
+    css: `background-image: url(${quote}${raw}${quote});`,
+    html: `<img src="${preview}" alt="">`,
+    base64,
+    raw,
+    preview,
+  };
+}

--- a/src/pages/DevUtilities/devutilities/svgDataUri.test.js
+++ b/src/pages/DevUtilities/devutilities/svgDataUri.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createSvgOutputs,
+  encodeSvgForDataUri,
+  SVG_DATA_URI_PREFIX,
+} from "./svgDataUri.js";
+
+const SVG = `<svg viewBox="0 0 24 24"><path fill="#fff" d="M0 0%"/><text>✓</text></svg>`;
+
+test("creates URL-encoded snippets without changing SVG content", () => {
+  const doubleQuoted = createSvgOutputs(SVG, "double");
+
+  assert.match(doubleQuoted.raw, /^data:image\/svg\+xml;utf8,%3Csvg/);
+  assert.match(doubleQuoted.raw, /viewBox=%220 0 24 24%22/);
+  assert.match(doubleQuoted.raw, /fill=%22%23fff%22/);
+  assert.match(doubleQuoted.raw, /M0 0%25/);
+  assert.match(doubleQuoted.raw, /%3Ctext%3E✓%3C\/text%3E/);
+  assert.equal(
+    doubleQuoted.css,
+    `background-image: url("${doubleQuoted.raw}");`,
+  );
+  assert.equal(
+    doubleQuoted.html,
+    `<img src="${doubleQuoted.preview}" alt="">`,
+  );
+
+  const singleQuoted = createSvgOutputs(
+    `<svg aria-label='sample'><path d='M0 0'/></svg>`,
+    "single",
+  );
+  assert.equal(
+    singleQuoted.css,
+    `background-image: url('${singleQuoted.raw}');`,
+  );
+  assert.match(singleQuoted.raw, /aria-label=%27sample%27/);
+});
+
+test("preserves entities and literal quotes in SVG text", () => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg"><text>It's &amp; "quoted"</text></svg>`;
+  const doubleQuoted = createSvgOutputs(svg, "double");
+  const singleQuoted = createSvgOutputs(svg, "single");
+
+  assert.match(doubleQuoted.raw, /It's %26amp; %22quoted%22/);
+  assert.match(singleQuoted.raw, /It%27s %26amp; "quoted"/);
+  assert.equal(
+    decodeURIComponent(doubleQuoted.raw.slice(SVG_DATA_URI_PREFIX.length)),
+    svg,
+  );
+  assert.equal(
+    decodeURIComponent(singleQuoted.raw.slice(SVG_DATA_URI_PREFIX.length)),
+    svg,
+  );
+  assert.match(doubleQuoted.html, /%26amp;/);
+});
+
+test("creates a Unicode-safe Base64 data URI", () => {
+  const { base64 } = createSvgOutputs(SVG);
+  const decoded = decodeURIComponent(
+    Array.from(atob(base64.split(",")[1]), (character) =>
+      `%${character.charCodeAt(0).toString(16).padStart(2, "0")}`,
+    ).join(""),
+  );
+
+  assert.equal(decoded, SVG);
+});
+
+test("returns empty output fields for blank input", () => {
+  assert.deepEqual(createSvgOutputs("  \n"), {
+    css: "",
+    html: "",
+    base64: "",
+    raw: "",
+    preview: "",
+  });
+  assert.equal(encodeSvgForDataUri("<svg></svg>"), "%3Csvg%3E%3C/svg%3E");
+});


### PR DESCRIPTION
## 📝 Description

Adds an offline SVG to Data URI utility with responsive light/dark UI, content-preserving quote controls, accessible live validation and preview, and individually copyable CSS, HTML, Base64, and URL-encoded outputs. The route, sidebar entry, and searchable Dev Utilities card are registered, with focused encoding coverage.

## 🔗 Related Issue

Closes #409

## 🎯 Type of Change

- [ ] `fix`: Bug fix
- [x] `feat`: New feature
- [x] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist

- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [ ] Added screenshots (if UI was changed) 📸
- [x] Tested locally on the latest version 🧪

## 📸 Screenshots (if applicable)

Splash-free light- and dark-theme screenshots of the populated converter were captured during the exact-build Chrome verification and retained in the review evidence bundle. They are intentionally not embedded in this draft, so the screenshot checklist item remains unchecked.

## Testing

- `OPENSSL_CONF=/dev/null node --test src/pages/DevUtilities/devutilities/svgDataUri.test.js` — passed (4 tests) in the clean network-disabled verifier
- `npm run lint` — passed with 0 errors (53 pre-existing repository warnings)
- `npx --no-install vite build --configLoader runner` — passed (284 modules transformed)
- local Chrome smoke against the exact production build — passed for entity-safe HTML image rendering, source-preserving double/single quote output, accessible status updates, and light/dark themes with no console errors

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1050:start -->
### Verification

[Northset proof-of-pass receipt M-1050](https://northset-oss.github.io/verification-pilot/receipts/M-1050/)  
This record covers Northset’s own contribution; it is not maintainer verification.
Maintainers can request a separate, private run for a PR already in their queue at oss@northset.ai.
For repositories already onboarded with Northset, adding `northset-verify` to a PR requests a run on that PR.
<!-- northset-receipt:M-1050:end -->
