### PR TITLE
feat: add CSS Custom Blob & Fancy Border Radius Generator

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,7 @@ import ListResources from "./pages/ResourceHub/resourcehub/ListResources";
 import Base64Url from "./pages/DevUtilities/devutilities/Base64Url";
 import BcryptGenerator from "./pages/DevUtilities/devutilities/BcryptGenerator";
 import BorderImageGenerator from "./pages/DevUtilities/devutilities/BorderImageGenerator";
+import FancyBorderRadiusGenerator from "./pages/DevUtilities/devutilities/FancyBorderRadiusGenerator";
 import ChmodCalculator from "./pages/DevUtilities/devutilities/ChmodCalculator";
 import ClipPathMaker from "./pages/DevUtilities/devutilities/ClipPathMaker";
 import CodeSandbox from "./pages/DevUtilities/devutilities/CodeSandbox";
@@ -528,6 +529,10 @@ function AppInner({ toggleHUD, hudVisible }) {
               <Route
                 path="/devutilities/border-image"
                 element={<BorderImageGenerator />}
+              />
+              <Route
+                path="/devutilities/fancy-border-radius"
+                element={<FancyBorderRadiusGenerator />}
               />
               <Route
                 path="/devutilities/glassmorphism"

--- a/src/config/sidebarSections.js
+++ b/src/config/sidebarSections.js
@@ -296,6 +296,12 @@ const SIDEBAR_SECTIONS = [
         path: "/devutilities/border-image",
       },
       {
+        label: "CSS Custom Blob & Fancy Border Radius",
+        description:
+          "Design organic blob shapes using visual handles and advanced 8-point border-radius.",
+        path: "/devutilities/fancy-border-radius",
+      },
+      {
         label: "Glassmorphism Playground",
         description: "Design glassmorphism effects with shadows and blur",
         path: "/devutilities/glassmorphism",

--- a/src/pages/DevUtilities/DevUtilities.jsx
+++ b/src/pages/DevUtilities/DevUtilities.jsx
@@ -1092,6 +1092,27 @@ const DevUtilities = () => {
       ),
     },
     {
+      title: "CSS Custom Blob & Fancy Border Radius",
+      description:
+        "Design organic blob shapes using visual handles and advanced 8-point border-radius.",
+      path: "/devutilities/fancy-border-radius",
+      icon: (
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 3c3.5 0 7 1.8 7 6.5S17 20 12 20s-7-3.5-7-10.5S8.5 3 12 3z"
+          />
+        </svg>
+      ),
+    },
+    {
       title: "Password Generator",
       description:
         "Generate secure passwords and analyze entropy, strength, and crack times.",

--- a/src/pages/DevUtilities/devutilities/FancyBorderRadiusGenerator.jsx
+++ b/src/pages/DevUtilities/devutilities/FancyBorderRadiusGenerator.jsx
@@ -1,0 +1,424 @@
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { toast } from "sonner";
+import {
+  FaArrowLeft,
+  FaCopy,
+  FaPlay,
+  FaStop,
+  FaSyncAlt,
+  FaUndo,
+} from "react-icons/fa";
+import { useTheme } from "../../../context/ThemeContext";
+
+// Corner order used by the CSS border-radius shorthand: TL, TR, BR, BL
+const CORNER_KEYS = ["tl", "tr", "br", "bl"];
+
+const DEFAULT_RADII = {
+  tlH: 30, trH: 70, brH: 70, blH: 30,
+  tlV: 30, trV: 30, brV: 70, blV: 70,
+};
+
+const PRESETS = [
+  { name: "Perfect Circle", radii: { tlH: 50, trH: 50, brH: 50, blH: 50, tlV: 50, trV: 50, brV: 50, blV: 50 } },
+  { name: "Organic Blob", radii: { tlH: 30, trH: 70, brH: 70, blH: 30, tlV: 30, trV: 30, brV: 70, blV: 70 } },
+  { name: "Liquid Button", radii: { tlH: 60, trH: 40, brH: 30, blH: 70, tlV: 60, trV: 30, brV: 70, blV: 40 } },
+  { name: "Egg", radii: { tlH: 50, trH: 50, brH: 50, blH: 50, tlV: 60, trV: 60, brV: 40, blV: 40 } },
+  { name: "Speech Bubble", radii: { tlH: 35, trH: 35, brH: 35, blH: 5, tlV: 35, trV: 35, brV: 10, blV: 35 } },
+];
+
+const clamp = (n, min, max) => Math.min(max, Math.max(min, n));
+const round1 = (n) => Math.round(n * 10) / 10;
+
+const radiiToCss = (r) =>
+  `${round1(r.tlH)}% ${round1(r.trH)}% ${round1(r.brH)}% ${round1(r.blH)}% / ${round1(r.tlV)}% ${round1(r.trV)}% ${round1(r.brV)}% ${round1(r.blV)}%`;
+
+// Cyclically rotates the 8 values so the morph target still looks organic
+// and always stays within the same 0-100 range as the source shape.
+const rotateRadii = (r) => ({
+  tlH: r.trH, trH: r.brH, brH: r.blH, blH: r.tlH,
+  tlV: r.trV, trV: r.brV, brV: r.blV, blV: r.tlV,
+});
+
+export default function FancyBorderRadiusGenerator() {
+  const { dark } = useTheme();
+  const containerRef = useRef(null);
+  const draggingHandle = useRef(null);
+  const rawId = useId().replace(/[^a-zA-Z0-9]/g, "");
+
+  const [radii, setRadii] = useState({ ...DEFAULT_RADII });
+  const [activePreset, setActivePreset] = useState("Organic Blob");
+  const [width, setWidth] = useState(280);
+  const [height, setHeight] = useState(280);
+  const [morphing, setMorphing] = useState(false);
+  const [duration, setDuration] = useState(4);
+  const [tailwindMode, setTailwindMode] = useState(false);
+
+  const theme = {
+    light: {
+      wrapper: "bg-[#F8F9FA] text-zinc-900",
+      heading: "text-zinc-900",
+      subtext: "text-zinc-500",
+      card: "bg-white border-zinc-200/85 shadow-sm",
+      input:
+        "bg-zinc-50 border-zinc-200 text-zinc-900 focus:border-zinc-400 focus:outline-none",
+      button: "bg-zinc-900 text-white hover:bg-zinc-800 transition-all duration-200 shadow-sm",
+      secondaryBtn:
+        "bg-white text-zinc-800 border-zinc-200 hover:bg-zinc-50 transition-all duration-200",
+      activeBtn: "bg-zinc-900 text-white border-zinc-900",
+      backLink:
+        "bg-white border-neutral-200 text-neutral-600 hover:text-black hover:border-neutral-350",
+      codeBox: "bg-zinc-900 text-zinc-100 border-zinc-800",
+      subtle: "border-zinc-100",
+      canvasBorder: "border-zinc-200",
+      blob: "bg-gradient-to-br from-zinc-800 to-zinc-500",
+    },
+    dark: {
+      wrapper: "bg-[#090A0F] text-zinc-100",
+      heading: "text-zinc-100",
+      subtext: "text-zinc-500",
+      card: "bg-zinc-900/50 border-zinc-800/85 backdrop-blur-md shadow-md",
+      input:
+        "bg-zinc-900 border-zinc-700 text-zinc-100 focus:border-zinc-500 focus:outline-none",
+      button: "bg-white text-zinc-900 hover:bg-zinc-100 transition-all duration-200 shadow-sm",
+      secondaryBtn:
+        "bg-zinc-800/50 text-zinc-300 border-zinc-700 hover:bg-zinc-700/50 transition-all duration-200",
+      activeBtn: "bg-white text-zinc-900 border-white",
+      backLink:
+        "bg-zinc-800/80 border-zinc-700 text-zinc-300 hover:text-white hover:border-zinc-600",
+      codeBox: "bg-black/40 text-emerald-400 border-zinc-800/80 font-mono",
+      subtle: "border-zinc-800/60",
+      canvasBorder: "border-zinc-800",
+      blob: "bg-gradient-to-br from-zinc-200 to-zinc-500",
+    },
+  };
+  const t = dark ? theme.dark : theme.light;
+
+  const primaryRadius = radiiToCss(radii);
+  const secondaryRadii = rotateRadii(radii);
+  const secondaryRadius = radiiToCss(secondaryRadii);
+
+  const cssOutput = `.fancy-blob {\n  width: ${width}px;\n  height: ${height}px;\n  border-radius: ${primaryRadius};\n}`;
+  const tailwindOutput = `w-[${width}px] h-[${height}px] rounded-[${primaryRadius.replace(/\s+/g, "_")}]`;
+
+  const keyframeName = `blobMorph${rawId}`;
+
+  const getRelativePoint = useCallback((clientX, clientY) => {
+    const rect = containerRef.current.getBoundingClientRect();
+    const x = clamp(((clientX - rect.left) / rect.width) * 100, 0, 100);
+    const y = clamp(((clientY - rect.top) / rect.height) * 100, 0, 100);
+    return [x, y];
+  }, []);
+
+  const handlePointerDown = (handleKey) => (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    draggingHandle.current = handleKey;
+  };
+
+  useEffect(() => {
+    const handleMove = (e) => {
+      const handle = draggingHandle.current;
+      if (!handle || !containerRef.current) return;
+      const [x, y] = getRelativePoint(e.clientX, e.clientY);
+
+      setRadii((prev) => {
+        const next = { ...prev };
+        switch (handle) {
+          case "tlH":
+            next.tlH = clamp(round1(x), 0, 100);
+            break;
+          case "trH":
+            next.trH = clamp(round1(100 - x), 0, 100);
+            break;
+          case "brH":
+            next.brH = clamp(round1(100 - x), 0, 100);
+            break;
+          case "blH":
+            next.blH = clamp(round1(x), 0, 100);
+            break;
+          case "tlV":
+            next.tlV = clamp(round1(y), 0, 100);
+            break;
+          case "trV":
+            next.trV = clamp(round1(y), 0, 100);
+            break;
+          case "brV":
+            next.brV = clamp(round1(100 - y), 0, 100);
+            break;
+          case "blV":
+            next.blV = clamp(round1(100 - y), 0, 100);
+            break;
+          default:
+            break;
+        }
+        return next;
+      });
+      setActivePreset(null);
+    };
+    const handleUp = () => {
+      draggingHandle.current = null;
+    };
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", handleUp);
+    return () => {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", handleUp);
+    };
+  }, [getRelativePoint]);
+
+  const applyPreset = (preset) => {
+    setRadii({ ...preset.radii });
+    setActivePreset(preset.name);
+    toast.success(`Applied ${preset.name} preset`);
+  };
+
+  const resetShape = () => {
+    setRadii({ ...DEFAULT_RADII });
+    setActivePreset("Organic Blob");
+    setMorphing(false);
+    toast.success("Shape reset");
+  };
+
+  const copyCss = () => {
+    navigator.clipboard.writeText(tailwindMode ? tailwindOutput : cssOutput);
+    toast.success(tailwindMode ? "Copied Tailwind classes!" : "Copied CSS to clipboard!");
+  };
+
+  // Handle anchor positions, expressed as {x%, y%} on the preview box.
+  const handlePositions = {
+    tlH: { x: radii.tlH, y: 0 },
+    trH: { x: 100 - radii.trH, y: 0 },
+    brH: { x: 100 - radii.brH, y: 100 },
+    blH: { x: radii.blH, y: 100 },
+    tlV: { x: 0, y: radii.tlV },
+    trV: { x: 100, y: radii.trV },
+    brV: { x: 100, y: 100 - radii.brV },
+    blV: { x: 0, y: 100 - radii.blV },
+  };
+
+  const handleLabels = {
+    tlH: "Top-left horizontal",
+    trH: "Top-right horizontal",
+    brH: "Bottom-right horizontal",
+    blH: "Bottom-left horizontal",
+    tlV: "Top-left vertical",
+    trV: "Top-right vertical",
+    brV: "Bottom-right vertical",
+    blV: "Bottom-left vertical",
+  };
+
+  return (
+    <div className={`min-h-screen ${t.wrapper} px-4 sm:px-6 py-6 sm:py-10 transition-colors duration-300`}>
+      <title>CSS Custom Blob & Fancy Border Radius Generator — DevTasks</title>
+      <meta
+        name="description"
+        content="Design organic blob shapes using visual drag handles and the 8-value fancy border-radius syntax. Fully offline."
+      />
+
+      {morphing && (
+        <style>{`
+          @keyframes ${keyframeName} {
+            0%, 100% { border-radius: ${primaryRadius}; }
+            50% { border-radius: ${secondaryRadius}; }
+          }
+        `}</style>
+      )}
+
+      <div className="max-w-6xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-6 sm:mb-8">
+          <Link
+            to="/devutilities"
+            className={`p-2 rounded-xl border transition-all duration-200 active:scale-95 flex items-center justify-center shrink-0 ${t.backLink}`}
+            title="Back to Utilities"
+          >
+            <FaArrowLeft className="w-4 h-4" />
+          </Link>
+          <div>
+            <h1 className={`text-xl sm:text-2xl font-semibold tracking-tight ${t.heading}`}>
+              CSS Custom Blob & Fancy Border Radius Generator
+            </h1>
+            <p className={`mt-0.5 text-xs sm:text-sm ${t.subtext}`}>
+              Drag the 8 handles to morph the shape, layer in animation, and export ready-to-use CSS. Fully offline.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid lg:grid-cols-2 gap-6 sm:gap-8 items-start">
+          {/* Left: Preview canvas */}
+          <div className="space-y-6">
+            <div className={`rounded-3xl border ${t.card} p-5 sm:p-6 space-y-4`}>
+              <div className="flex items-center justify-between">
+                <h2 className={`text-lg font-semibold tracking-tight ${t.heading}`}>Preview</h2>
+                <button
+                  onClick={resetShape}
+                  className={`px-3 py-1.5 rounded-xl font-bold text-[11px] uppercase tracking-widest flex items-center gap-1.5 ${t.secondaryBtn}`}
+                  title="Reset shape"
+                >
+                  <FaUndo className="w-3 h-3" /> Reset
+                </button>
+              </div>
+
+              <div
+                ref={containerRef}
+                className={`relative w-full flex items-center justify-center rounded-2xl border ${t.canvasBorder} overflow-visible select-none touch-none py-10`}
+              >
+                <div
+                  className={`${t.blob} shrink-0`}
+                  style={{
+                    width: `${width}px`,
+                    height: `${height}px`,
+                    maxWidth: "100%",
+                    borderRadius: primaryRadius,
+                    animation: morphing ? `${keyframeName} ${duration}s ease-in-out infinite` : "none",
+                  }}
+                />
+
+                {/* Draggable handles, positioned relative to the container box */}
+                <div className="absolute inset-0 py-10 pointer-events-none">
+                  <div className="relative w-full h-full mx-auto pointer-events-none" style={{ maxWidth: `${width}px` }}>
+                    {CORNER_KEYS.flatMap((corner) => [`${corner}H`, `${corner}V`]).map((key) => {
+                      const pos = handlePositions[key];
+                      return (
+                        <div
+                          key={key}
+                          onPointerDown={handlePointerDown(key)}
+                          title={`${handleLabels[key]} — drag along the edge`}
+                          className="absolute w-4 h-4 rounded-full bg-indigo-500 border-2 border-white shadow-md cursor-grab active:cursor-grabbing pointer-events-auto"
+                          style={{
+                            left: `${pos.x}%`,
+                            top: `${pos.y}%`,
+                            transform: "translate(-50%, -50%)",
+                          }}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+
+              <p className={`text-[11px] ${t.subtext}`}>
+                Each corner has a horizontal and a vertical handle — drag them along the box edges to shape the blob.
+              </p>
+            </div>
+
+            {/* Dimensions */}
+            <div className={`rounded-3xl border ${t.card} p-5 sm:p-6 space-y-4`}>
+              <h2 className={`text-lg font-semibold tracking-tight ${t.heading}`}>Dimensions</h2>
+              <div className="space-y-3">
+                <div className="flex items-center gap-3">
+                  <span className={`text-xs w-14 ${t.subtext}`}>Width</span>
+                  <input
+                    type="range"
+                    min="120"
+                    max="500"
+                    value={width}
+                    onChange={(e) => setWidth(Number(e.target.value))}
+                    className="flex-1 accent-indigo-500 h-1.5 bg-zinc-200 dark:bg-zinc-800 rounded-lg cursor-pointer"
+                  />
+                  <span className={`text-xs font-mono w-14 text-right ${t.subtext}`}>{width}px</span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className={`text-xs w-14 ${t.subtext}`}>Height</span>
+                  <input
+                    type="range"
+                    min="120"
+                    max="500"
+                    value={height}
+                    onChange={(e) => setHeight(Number(e.target.value))}
+                    className="flex-1 accent-indigo-500 h-1.5 bg-zinc-200 dark:bg-zinc-800 rounded-lg cursor-pointer"
+                  />
+                  <span className={`text-xs font-mono w-14 text-right ${t.subtext}`}>{height}px</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Right: Presets, animation, output */}
+          <div className="space-y-6">
+            {/* Presets */}
+            <div className={`rounded-3xl border ${t.card} p-5 sm:p-6 space-y-3`}>
+              <h2 className={`text-lg font-semibold tracking-tight ${t.heading}`}>Shape Presets</h2>
+              <div className="grid grid-cols-3 gap-2">
+                {PRESETS.map((preset) => (
+                  <button
+                    key={preset.name}
+                    onClick={() => applyPreset(preset)}
+                    className={`px-2 py-2 rounded-xl border text-[11px] font-semibold text-center transition-all duration-200 ${
+                      activePreset === preset.name ? t.activeBtn : t.secondaryBtn
+                    }`}
+                  >
+                    {preset.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Animation */}
+            <div className={`rounded-3xl border ${t.card} p-5 sm:p-6 space-y-4`}>
+              <div className="flex items-center justify-between">
+                <h2 className={`text-lg font-semibold tracking-tight ${t.heading}`}>Morph Animation</h2>
+                <button
+                  onClick={() => setMorphing((v) => !v)}
+                  className={`px-3 py-1.5 rounded-xl text-[11px] font-bold uppercase tracking-widest border flex items-center gap-1.5 transition-all duration-200 ${
+                    morphing ? t.activeBtn : t.secondaryBtn
+                  }`}
+                >
+                  {morphing ? <FaStop className="w-3 h-3" /> : <FaPlay className="w-3 h-3" />}
+                  {morphing ? "Stop" : "Play"}
+                </button>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className={`text-xs w-16 ${t.subtext}`}>Speed</span>
+                <input
+                  type="range"
+                  min="1"
+                  max="10"
+                  step="0.5"
+                  value={duration}
+                  onChange={(e) => setDuration(Number(e.target.value))}
+                  className="flex-1 accent-indigo-500 h-1.5 bg-zinc-200 dark:bg-zinc-800 rounded-lg cursor-pointer"
+                />
+                <span className={`text-xs font-mono w-10 text-right ${t.subtext}`}>{duration}s</span>
+              </div>
+              <p className={`text-[11px] ${t.subtext}`}>
+                Morphs between the current shape and an auto-generated offset for a fluid, liquid motion.
+              </p>
+            </div>
+
+            {/* CSS Output */}
+            <div className={`rounded-3xl border ${t.card} p-5 sm:p-6 space-y-3`}>
+              <div className="flex items-center justify-between">
+                <h2 className={`text-lg font-semibold tracking-tight ${t.heading}`}>CSS Output</h2>
+                <button
+                  onClick={() => setTailwindMode((v) => !v)}
+                  className={`px-3 py-1.5 rounded-xl text-[11px] font-bold uppercase tracking-widest border flex items-center gap-1.5 transition-all duration-200 ${
+                    tailwindMode ? t.activeBtn : t.secondaryBtn
+                  }`}
+                  title="Toggle Tailwind class syntax"
+                >
+                  <FaSyncAlt className="w-3 h-3" /> Tailwind
+                </button>
+              </div>
+              <div className="relative">
+                <pre
+                  className={`p-4 rounded-2xl border text-xs overflow-x-auto whitespace-pre-wrap break-all select-all ${t.codeBox}`}
+                >
+                  {tailwindMode ? tailwindOutput : cssOutput}
+                </pre>
+                <button
+                  onClick={copyCss}
+                  className="absolute right-3 top-3 p-2 rounded-xl bg-zinc-850 hover:bg-zinc-800 text-white transition-colors active:scale-95 flex items-center gap-1.5 text-xs font-semibold shadow-md"
+                  title="Copy to clipboard"
+                >
+                  <FaCopy className="w-3 h-3" /> Copy
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Features

Closes #406

This PR introduces a **CSS Custom Blob & Fancy Border-Radius Generator** utility to DevTasks, fully built with React and Tailwind CSS matching the existing UI/UX and dark/light mode standards.

#### ✨ Key Features
- **Visual Drag & Drop Handles:** 8 interactive control handles (2 per corner: horizontal & vertical) to visually customize non-standard `border-radius` values in real-time.
- **Preset Gallery:** Quick selection of popular organic shapes (`Organic Blob`, `Liquid Button`, `Egg`, `Speech Bubble`, and `Circle`).
- **Interactive Morphing Animation:** Toggleable CSS keyframe animation preview that smooth-morphs the shape into a generated secondary blob state.
- **Dimensional Controls:** Sliders for live width and height adjustments.
- **Export Capabilities:** One-click copy for both raw **CSS** (`border-radius`, `width`, `height`, animation) and **Tailwind CSS** equivalent classes.

---

### 🔍 Changes Overview

- `src/pages/DevUtilities/devutilities/FancyBorderRadiusGenerator.jsx`: Main utility component implementation.
- `src/App.jsx`: Added route `/devutilities/fancy-border-radius`.
- `src/config/sidebarSections.js`: Added entry under the **Dev Utilities** sidebar section.
- `src/pages/DevUtilities/DevUtilities.jsx`: Added the tool card in the Dev Utilities landing page.

---

### 🧪 Testing & Verification

- [x] Tested dragging all 8 handles across light/dark themes.
- [x] Verified CSS keyframe injection works seamlessly without conflicts across instances.
- [x] Verified responsiveness across different screen sizes.
- [x] Ran `npm run lint` and `npm run build` locally with zero errors.

## 📸 Screenshots 

<img width="1920" height="851" alt="image" src="https://github.com/user-attachments/assets/6b130e64-43d9-4c2f-bfce-34485be65164" />

<img width="1920" height="849" alt="image" src="https://github.com/user-attachments/assets/4f740c73-c580-4002-8e7a-8e04ea6b4436" />

