### PR TITLE
Feature/add timezone converter tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Local Claude Code instructions
+CLAUDE.md

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,6 +75,7 @@ import SvgSpritesheetMerger from "./pages/DevUtilities/devutilities/SvgSpriteshe
 import SlugGenerator from "./pages/DevUtilities/devutilities/SlugGenerator";
 import TextCaseConverter from "./pages/DevUtilities/devutilities/TextCaseConverter";
 import TimestampConverter from "./pages/DevUtilities/devutilities/TimestampConverter";
+import TimezoneConverter from "./pages/DevUtilities/devutilities/TimezoneConverter";
 import TokenGenerator from "./pages/DevUtilities/devutilities/TokenGenerator";
 import UrlParserBuilder from "./pages/DevUtilities/devutilities/UrlParserBuilder";
 import UserAgentParser from "./pages/DevUtilities/devutilities/UserAgentParser";
@@ -457,6 +458,10 @@ function AppInner({ toggleHUD, hudVisible }) {
               <Route
                 path="/devutilities/timestamp"
                 element={<TimestampConverter />}
+              />
+              <Route
+                path="/devutilities/timezone-converter"
+                element={<TimezoneConverter />}
               />
               <Route path="/devutilities/uuid" element={<UuidGenerator />} />
               <Route path="/devutilities/jwt" element={<JwtDecoder />} />

--- a/src/config/sidebarSections.js
+++ b/src/config/sidebarSections.js
@@ -251,6 +251,11 @@ const SIDEBAR_SECTIONS = [
         path: "/devutilities/timestamp",
       },
       {
+        label: "Timezone Converter",
+        description: "Convert date/time across timezones with a live world clock.",
+        path: "/devutilities/timezone-converter",
+      },
+      {
         label: "UUID Generator",
         description: "Generate UUIDs",
         path: "/devutilities/uuid",

--- a/src/pages/DevUtilities/DevUtilities.jsx
+++ b/src/pages/DevUtilities/DevUtilities.jsx
@@ -638,6 +638,29 @@ const DevUtilities = () => {
     },
 
     {
+      title: "Timezone Converter",
+      description:
+        "Convert date/time across timezones and track a live multi-timezone world clock, fully offline.",
+      path: "/devutilities/timezone-converter",
+      keywords: "timezone convert world clock utc offset dst",
+      icon: (
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      ),
+    },
+
+    {
       title: "Markdown Studio",
       description:
         "Write markdown and instantly preview rendered HTML output, or build markdown tables visually.",

--- a/src/pages/DevUtilities/devutilities/TimezoneConverter.jsx
+++ b/src/pages/DevUtilities/devutilities/TimezoneConverter.jsx
@@ -98,6 +98,45 @@ const localToUtcIso = (dateTimeLocal, timeZone) => {
   return new Date(guess);
 };
 
+const getLocalHour = (date, timeZone) => {
+  try {
+    const hour = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hourCycle: "h23",
+      hour: "2-digit",
+    }).formatToParts(date).find((p) => p.type === "hour").value;
+    return Number(hour) % 24;
+  } catch {
+    return null;
+  }
+};
+
+// Collapses a set of individually-true hour indices (0-23) into contiguous
+// "start-end" ranges so overlap results read as e.g. "14:00-17:00" instead
+// of a list of 24 booleans.
+const collapseHourRanges = (hours) => {
+  const sorted = [...hours].sort((a, b) => a - b);
+  const ranges = [];
+  let rangeStart = null;
+  let prev = null;
+
+  sorted.forEach((hour) => {
+    if (rangeStart === null) {
+      rangeStart = hour;
+    } else if (hour !== prev + 1) {
+      ranges.push([rangeStart, prev]);
+      rangeStart = hour;
+    }
+    prev = hour;
+  });
+  if (rangeStart !== null) ranges.push([rangeStart, prev]);
+
+  return ranges.map(
+    ([start, end]) =>
+      `${String(start).padStart(2, "0")}:00–${String((end + 1) % 24).padStart(2, "0")}:00`
+  );
+};
+
 const TimezoneConverter = () => {
   const { dark } = useTheme();
   const [now, setNow] = useState(() => new Date());
@@ -113,6 +152,8 @@ const TimezoneConverter = () => {
     "Asia/Tokyo",
   ]);
   const [zonePicker, setZonePicker] = useState("");
+  const [workStart, setWorkStart] = useState(9);
+  const [workEnd, setWorkEnd] = useState(18);
 
   const allZones = useMemo(() => getSupportedTimezones(), []);
 
@@ -124,6 +165,37 @@ const TimezoneConverter = () => {
   const referenceDate = dateTimeInput
     ? localToUtcIso(dateTimeInput, sourceZone)
     : now;
+
+  // Build a 24-hour grid (UTC hours of the reference date) and, for each
+  // pinned zone, whether that hour falls inside the configured working
+  // window in the zone's own local time. Hours where every pinned zone is
+  // "in office hours" are the meeting overlap slots.
+  const overlapGrid = useMemo(() => {
+    const dayStartUtc = Date.UTC(
+      referenceDate.getUTCFullYear(),
+      referenceDate.getUTCMonth(),
+      referenceDate.getUTCDate()
+    );
+
+    const hours = Array.from({ length: 24 }, (_, h) => {
+      const hourDate = new Date(dayStartUtc + h * 3600000);
+      const zoneHours = pinnedZones.map((zone) => {
+        const localHour = getLocalHour(hourDate, zone);
+        const inRange =
+          localHour !== null && localHour >= workStart && localHour < workEnd;
+        return { zone, localHour, inRange };
+      });
+      const allInRange =
+        zoneHours.length > 0 && zoneHours.every((z) => z.inRange);
+      return { utcHour: h, zoneHours, allInRange };
+    });
+
+    const overlapRanges = collapseHourRanges(
+      hours.filter((h) => h.allInRange).map((h) => h.utcHour)
+    );
+
+    return { hours, overlapRanges };
+  }, [referenceDate, pinnedZones, workStart, workEnd]);
 
   const handleUseNow = () => {
     const parts = new Intl.DateTimeFormat("en-CA", {
@@ -352,6 +424,124 @@ const TimezoneConverter = () => {
                 </p>
               )}
             </div>
+          </div>
+
+          {/* Meeting overlap finder */}
+          <div className={`rounded-3xl border ${t.card} p-6`}>
+            <p
+              className={`text-xs uppercase tracking-widest font-medium mb-5 ${t.subtext}`}
+            >
+              Meeting Overlap Finder
+            </p>
+
+            <div className="flex items-center gap-3 mb-5 flex-wrap">
+              <label className={`text-sm ${t.subtext}`}>Working hours</label>
+              <select
+                value={workStart}
+                onChange={(e) => setWorkStart(Number(e.target.value))}
+                className={`px-3 py-2 rounded-xl border text-sm ${t.select}`}
+              >
+                {Array.from({ length: 24 }, (_, h) => (
+                  <option key={h} value={h}>
+                    {String(h).padStart(2, "0")}:00
+                  </option>
+                ))}
+              </select>
+              <span className={`text-sm ${t.subtext}`}>to</span>
+              <select
+                value={workEnd}
+                onChange={(e) => setWorkEnd(Number(e.target.value))}
+                className={`px-3 py-2 rounded-xl border text-sm ${t.select}`}
+              >
+                {Array.from({ length: 24 }, (_, h) => (
+                  <option key={h} value={h + 1}>
+                    {String((h + 1) % 24).padStart(2, "0")}:00
+                  </option>
+                ))}
+              </select>
+              <span className={`text-sm ${t.subtext}`}>in each zone's local time</span>
+            </div>
+
+            {pinnedZones.length === 0 ? (
+              <p className={`text-sm ${t.subtext}`}>
+                Pin at least one timezone above to find overlapping hours.
+              </p>
+            ) : (
+              <>
+                <div className="overflow-x-auto">
+                  <div className="min-w-[720px] space-y-1.5">
+                    {pinnedZones.map((zone) => (
+                      <div key={zone} className="flex items-center gap-2">
+                        <p
+                          className={`w-36 shrink-0 text-xs truncate ${t.subtext}`}
+                          title={zone}
+                        >
+                          {zone}
+                        </p>
+                        <div className="flex gap-0.5 flex-1">
+                          {overlapGrid.hours.map((hourEntry) => {
+                            const zoneHour = hourEntry.zoneHours.find(
+                              (z) => z.zone === zone
+                            );
+                            return (
+                              <div
+                                key={hourEntry.utcHour}
+                                title={`${zone}: ${String(zoneHour.localHour).padStart(2, "0")}:00`}
+                                className={`flex-1 h-6 rounded-sm flex items-center justify-center text-[9px] font-mono ${
+                                  zoneHour.inRange
+                                    ? dark
+                                      ? "bg-emerald-500/70 text-emerald-50"
+                                      : "bg-emerald-500 text-white"
+                                    : dark
+                                      ? "bg-zinc-800 text-zinc-600"
+                                      : "bg-zinc-100 text-zinc-400"
+                                }`}
+                              >
+                                {zoneHour.localHour}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ))}
+
+                    <div className="flex items-center gap-2 pt-1">
+                      <p className={`w-36 shrink-0 text-xs font-medium ${t.heading}`}>
+                        All zones (UTC)
+                      </p>
+                      <div className="flex gap-0.5 flex-1">
+                        {overlapGrid.hours.map((hourEntry) => (
+                          <div
+                            key={hourEntry.utcHour}
+                            title={`${String(hourEntry.utcHour).padStart(2, "0")}:00 UTC`}
+                            className={`flex-1 h-6 rounded-sm flex items-center justify-center text-[9px] font-mono border-2 ${
+                              hourEntry.allInRange
+                                ? "border-emerald-500 bg-emerald-500/20"
+                                : "border-transparent"
+                            } ${t.subtext}`}
+                          >
+                            {String(hourEntry.utcHour).padStart(2, "0")}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className={`mt-5 px-4 py-3 rounded-xl border text-sm ${t.result}`}>
+                  {overlapGrid.overlapRanges.length > 0 ? (
+                    <>
+                      <span className={`font-medium ${t.heading}`}>
+                        Overlap (UTC):{" "}
+                      </span>
+                      {overlapGrid.overlapRanges.join(", ")}
+                    </>
+                  ) : (
+                    "No hour of the day falls within working hours for every pinned zone."
+                  )}
+                </div>
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/src/pages/DevUtilities/devutilities/TimezoneConverter.jsx
+++ b/src/pages/DevUtilities/devutilities/TimezoneConverter.jsx
@@ -137,6 +137,41 @@ const collapseHourRanges = (hours) => {
   );
 };
 
+const PINNED_ZONES_STORAGE_KEY = "timezone_converter_pinned_zones";
+const DEFAULT_PINNED_ZONES = [
+  "UTC",
+  "America/New_York",
+  "Europe/London",
+  "Asia/Kolkata",
+  "Asia/Tokyo",
+];
+
+// Initialize pinned zones from storage only in the browser.
+const loadPinnedZones = () => {
+  if (typeof window === "undefined") {
+    return DEFAULT_PINNED_ZONES;
+  }
+
+  try {
+    const saved = localStorage.getItem(PINNED_ZONES_STORAGE_KEY);
+
+    if (!saved) {
+      return DEFAULT_PINNED_ZONES;
+    }
+
+    const parsed = JSON.parse(saved);
+
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      return DEFAULT_PINNED_ZONES;
+    }
+
+    return parsed.filter((zone) => typeof zone === "string");
+  } catch (error) {
+    console.error("Unable to load pinned timezones", error);
+    return DEFAULT_PINNED_ZONES;
+  }
+};
+
 const TimezoneConverter = () => {
   const { dark } = useTheme();
   const [now, setNow] = useState(() => new Date());
@@ -144,13 +179,7 @@ const TimezoneConverter = () => {
     Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"
   );
   const [dateTimeInput, setDateTimeInput] = useState("");
-  const [pinnedZones, setPinnedZones] = useState([
-    "UTC",
-    "America/New_York",
-    "Europe/London",
-    "Asia/Kolkata",
-    "Asia/Tokyo",
-  ]);
+  const [pinnedZones, setPinnedZones] = useState(loadPinnedZones);
   const [zonePicker, setZonePicker] = useState("");
   const [workStart, setWorkStart] = useState(9);
   const [workEnd, setWorkEnd] = useState(18);
@@ -161,6 +190,14 @@ const TimezoneConverter = () => {
     const id = setInterval(() => setNow(new Date()), 1000);
     return () => clearInterval(id);
   }, []);
+
+  // Mirror pinned zones back to localStorage whenever the list changes.
+  useEffect(() => {
+    localStorage.setItem(
+      PINNED_ZONES_STORAGE_KEY,
+      JSON.stringify(pinnedZones)
+    );
+  }, [pinnedZones]);
 
   const referenceDate = dateTimeInput
     ? localToUtcIso(dateTimeInput, sourceZone)

--- a/src/pages/DevUtilities/devutilities/TimezoneConverter.jsx
+++ b/src/pages/DevUtilities/devutilities/TimezoneConverter.jsx
@@ -1,0 +1,362 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useTheme } from "../../../context/ThemeContext";
+
+const COMMON_TIMEZONES = [
+  "UTC",
+  "America/Los_Angeles",
+  "America/Denver",
+  "America/Chicago",
+  "America/New_York",
+  "America/Sao_Paulo",
+  "Europe/London",
+  "Europe/Berlin",
+  "Europe/Moscow",
+  "Africa/Cairo",
+  "Asia/Dubai",
+  "Asia/Kolkata",
+  "Asia/Dhaka",
+  "Asia/Bangkok",
+  "Asia/Shanghai",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+  "Pacific/Auckland",
+];
+
+const getSupportedTimezones = () => {
+  if (typeof Intl.supportedValuesOf === "function") {
+    try {
+      return Intl.supportedValuesOf("timeZone");
+    } catch {
+      return COMMON_TIMEZONES;
+    }
+  }
+  return COMMON_TIMEZONES;
+};
+
+const formatInZone = (date, timeZone) => {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      dateStyle: "medium",
+      timeStyle: "medium",
+    }).format(date);
+
+    const offsetPart = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      timeZoneName: "shortOffset",
+    })
+      .formatToParts(date)
+      .find((p) => p.type === "timeZoneName");
+
+    return {
+      formatted: parts,
+      offset: offsetPart ? offsetPart.value : "",
+    };
+  } catch {
+    return { formatted: "Invalid timezone", offset: "" };
+  }
+};
+
+const localToUtcIso = (dateTimeLocal, timeZone) => {
+  // Interpret the given "wall clock" date/time as if it were observed in `timeZone`,
+  // then resolve to the equivalent UTC instant using an offset-correction loop.
+  const [datePart, timePart] = dateTimeLocal.split("T");
+  const [year, month, day] = datePart.split("-").map(Number);
+  const [hour, minute] = timePart.split(":").map(Number);
+
+  let guess = Date.UTC(year, month - 1, day, hour, minute);
+
+  for (let i = 0; i < 2; i += 1) {
+    const dtf = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hourCycle: "h23",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    const parts = dtf.formatToParts(new Date(guess));
+    const map = {};
+    parts.forEach((p) => {
+      map[p.type] = p.value;
+    });
+    const asUtc = Date.UTC(
+      Number(map.year),
+      Number(map.month) - 1,
+      Number(map.day),
+      Number(map.hour === "24" ? 0 : map.hour),
+      Number(map.minute),
+      Number(map.second)
+    );
+    const diff = Date.UTC(year, month - 1, day, hour, minute) - asUtc;
+    guess += diff;
+  }
+
+  return new Date(guess);
+};
+
+const TimezoneConverter = () => {
+  const { dark } = useTheme();
+  const [now, setNow] = useState(() => new Date());
+  const [sourceZone, setSourceZone] = useState(
+    Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"
+  );
+  const [dateTimeInput, setDateTimeInput] = useState("");
+  const [pinnedZones, setPinnedZones] = useState([
+    "UTC",
+    "America/New_York",
+    "Europe/London",
+    "Asia/Kolkata",
+    "Asia/Tokyo",
+  ]);
+  const [zonePicker, setZonePicker] = useState("");
+
+  const allZones = useMemo(() => getSupportedTimezones(), []);
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const referenceDate = dateTimeInput
+    ? localToUtcIso(dateTimeInput, sourceZone)
+    : now;
+
+  const handleUseNow = () => {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: sourceZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(now);
+    const map = {};
+    parts.forEach((p) => {
+      map[p.type] = p.value;
+    });
+    setDateTimeInput(`${map.year}-${map.month}-${map.day}T${map.hour}:${map.minute}`);
+  };
+
+  const addZone = () => {
+    if (!zonePicker || pinnedZones.includes(zonePicker)) return;
+    setPinnedZones([...pinnedZones, zonePicker]);
+    setZonePicker("");
+  };
+
+  const removeZone = (zone) => {
+    setPinnedZones(pinnedZones.filter((z) => z !== zone));
+  };
+
+  const theme = {
+    light: {
+      wrapper: "bg-[#F8F9FA] text-zinc-900",
+      heading: "text-zinc-900",
+      subtext: "text-zinc-500",
+      card: "bg-white border-zinc-200/85",
+      input:
+        "bg-zinc-50 border-zinc-200 text-zinc-900 placeholder-zinc-400 focus:border-zinc-400 focus:outline-none",
+      select:
+        "bg-zinc-50 border-zinc-200 text-zinc-900 focus:border-zinc-400 focus:outline-none",
+      button: "bg-zinc-900 text-white hover:bg-zinc-700 transition-colors",
+      result: "bg-zinc-50 border-zinc-200 text-zinc-700",
+      backLink: "text-zinc-500 hover:text-zinc-900 transition-colors",
+      remove: "text-zinc-400 hover:text-red-500 transition-colors",
+    },
+    dark: {
+      wrapper: "bg-[#090A0F] text-zinc-100",
+      heading: "text-zinc-100",
+      subtext: "text-zinc-500",
+      card: "bg-zinc-900/50 border-zinc-800/85",
+      input:
+        "bg-zinc-900 border-zinc-700 text-zinc-100 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none",
+      select:
+        "bg-zinc-900 border-zinc-700 text-zinc-100 focus:border-zinc-500 focus:outline-none",
+      button: "bg-white text-zinc-900 hover:bg-zinc-200 transition-colors",
+      result: "bg-zinc-900 border-zinc-700 text-zinc-300",
+      backLink: "text-zinc-500 hover:text-zinc-100 transition-colors",
+      remove: "text-zinc-600 hover:text-red-400 transition-colors",
+    },
+  };
+
+  const t = dark ? theme.dark : theme.light;
+
+  return (
+    <div className={`min-h-screen ${t.wrapper} px-6 py-10`}>
+      <title>Timezone Converter — DevTasks</title>
+      <meta
+        name="description"
+        content="Convert date and time across timezones and view a live multi-timezone world clock, fully offline."
+      />
+
+      <div className="max-w-2xl mx-auto">
+        <div className="flex items-center gap-3 mb-8">
+          <Link
+            to="/devutilities"
+            className={`p-2.5 rounded-xl border transition-all duration-200 active:scale-95 flex items-center justify-center shrink-0 ${
+              dark
+                ? "bg-zinc-800/80 border-zinc-700 text-zinc-300 hover:text-white hover:border-zinc-600"
+                : "bg-white border-neutral-200 text-neutral-600 hover:text-black hover:border-neutral-350"
+            }`}
+            title="Back to Workspace"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2.5}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </Link>
+          <div>
+            <h1 className={`text-2xl font-semibold tracking-tight ${t.heading}`}>
+              Timezone Converter
+            </h1>
+            <p className={`mt-1 text-sm ${t.subtext}`}>
+              Convert a date/time across timezones and track a live world clock.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-5">
+          {/* Source date/time */}
+          <div className={`rounded-3xl border ${t.card} p-6`}>
+            <div className="flex items-center justify-between mb-5">
+              <p
+                className={`text-xs uppercase tracking-widest font-medium ${t.subtext}`}
+              >
+                Source Date & Time
+              </p>
+              <button
+                type="button"
+                onClick={handleUseNow}
+                className={`px-4 py-2 rounded-xl border font-black text-xs uppercase tracking-widest transition-all duration-300 hover:scale-105 active:scale-95 ${
+                  dark
+                    ? "bg-white text-black border-white hover:bg-zinc-200"
+                    : "bg-black text-white border-black hover:bg-zinc-800"
+                }`}
+              >
+                Use Now
+              </button>
+            </div>
+            <div className="space-y-3">
+              <select
+                value={sourceZone}
+                onChange={(e) => setSourceZone(e.target.value)}
+                className={`w-full px-4 py-3 rounded-xl border text-sm ${t.select}`}
+              >
+                {allZones.map((zone) => (
+                  <option key={zone} value={zone}>
+                    {zone}
+                  </option>
+                ))}
+              </select>
+              <input
+                type="datetime-local"
+                value={dateTimeInput}
+                onChange={(e) => setDateTimeInput(e.target.value)}
+                className={`w-full px-4 py-3 rounded-xl border text-sm ${t.input}`}
+              />
+              <p className={`text-xs ${t.subtext}`}>
+                Leave blank to use the live current time.
+              </p>
+            </div>
+          </div>
+
+          {/* World clock */}
+          <div className={`rounded-3xl border ${t.card} p-6`}>
+            <div className="flex items-center justify-between mb-5">
+              <p
+                className={`text-xs uppercase tracking-widest font-medium ${t.subtext}`}
+              >
+                World Clock
+              </p>
+            </div>
+
+            <div className="flex gap-3 mb-5">
+              <select
+                value={zonePicker}
+                onChange={(e) => setZonePicker(e.target.value)}
+                className={`flex-1 px-4 py-3 rounded-xl border text-sm ${t.select}`}
+              >
+                <option value="">Add a timezone…</option>
+                {allZones
+                  .filter((zone) => !pinnedZones.includes(zone))
+                  .map((zone) => (
+                    <option key={zone} value={zone}>
+                      {zone}
+                    </option>
+                  ))}
+              </select>
+              <button
+                onClick={addZone}
+                className={`px-5 py-2.5 rounded-xl text-sm font-medium cursor-pointer ${t.button}`}
+              >
+                Add
+              </button>
+            </div>
+
+            <div className="space-y-3">
+              {pinnedZones.map((zone) => {
+                const { formatted, offset } = formatInZone(referenceDate, zone);
+                return (
+                  <div
+                    key={zone}
+                    className={`flex items-center justify-between px-4 py-3 rounded-xl border text-sm ${t.result}`}
+                  >
+                    <div>
+                      <p className={`font-medium ${t.heading}`}>{zone}</p>
+                      <p className={`font-mono text-xs mt-0.5 ${t.subtext}`}>
+                        {offset}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <p className="font-mono">{formatted}</p>
+                      <button
+                        type="button"
+                        onClick={() => removeZone(zone)}
+                        className={`p-1 ${t.remove}`}
+                        title="Remove"
+                      >
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M6 18L18 6M6 6l12 12"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+              {pinnedZones.length === 0 && (
+                <p className={`text-sm ${t.subtext}`}>
+                  No timezones pinned yet. Add one above.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TimezoneConverter;

--- a/src/pages/DevUtilities/devutilities/TimezoneConverter.jsx
+++ b/src/pages/DevUtilities/devutilities/TimezoneConverter.jsx
@@ -58,6 +58,58 @@ const formatInZone = (date, timeZone) => {
   }
 };
 
+// Returns the UTC offset of `timeZone` at `date`, in minutes (positive =
+// ahead of UTC), by comparing the zone's wall-clock reading against the
+// instant's actual UTC time.
+const getOffsetMinutes = (date, timeZone) => {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const parts = dtf.formatToParts(date);
+  const map = {};
+  parts.forEach((p) => {
+    map[p.type] = p.value;
+  });
+  const asUtc = Date.UTC(
+    Number(map.year),
+    Number(map.month) - 1,
+    Number(map.day),
+    Number(map.hour === "24" ? 0 : map.hour),
+    Number(map.minute),
+    Number(map.second)
+  );
+  return (asUtc - date.getTime()) / 60000;
+};
+
+// A zone is "in DST" at `date` when its current offset is greater than its
+// standard (non-DST) offset. The standard offset is derived by sampling
+// offsets in January and July: DST always shifts clocks forward relative to
+// standard time, so the smaller of the two samples is the standard offset,
+// regardless of hemisphere. Zones without DST have identical samples.
+const isObservingDst = (date, timeZone) => {
+  const year = date.getUTCFullYear();
+  const janOffset = getOffsetMinutes(
+    new Date(Date.UTC(year, 0, 15, 12)),
+    timeZone
+  );
+  const julOffset = getOffsetMinutes(
+    new Date(Date.UTC(year, 6, 15, 12)),
+    timeZone
+  );
+
+  if (janOffset === julOffset) return false;
+
+  const standardOffset = Math.min(janOffset, julOffset);
+  return getOffsetMinutes(date, timeZone) > standardOffset;
+};
+
 const localToUtcIso = (dateTimeLocal, timeZone) => {
   // Interpret the given "wall clock" date/time as if it were observed in `timeZone`,
   // then resolve to the equivalent UTC instant using an offset-correction loop.
@@ -68,29 +120,8 @@ const localToUtcIso = (dateTimeLocal, timeZone) => {
   let guess = Date.UTC(year, month - 1, day, hour, minute);
 
   for (let i = 0; i < 2; i += 1) {
-    const dtf = new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      hourCycle: "h23",
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    });
-    const parts = dtf.formatToParts(new Date(guess));
-    const map = {};
-    parts.forEach((p) => {
-      map[p.type] = p.value;
-    });
-    const asUtc = Date.UTC(
-      Number(map.year),
-      Number(map.month) - 1,
-      Number(map.day),
-      Number(map.hour === "24" ? 0 : map.hour),
-      Number(map.minute),
-      Number(map.second)
-    );
+    const offsetMinutes = getOffsetMinutes(new Date(guess), timeZone);
+    const asUtc = guess + offsetMinutes * 60000;
     const diff = Date.UTC(year, month - 1, day, hour, minute) - asUtc;
     guess += diff;
   }
@@ -418,13 +449,28 @@ const TimezoneConverter = () => {
             <div className="space-y-3">
               {pinnedZones.map((zone) => {
                 const { formatted, offset } = formatInZone(referenceDate, zone);
+                const dst = isObservingDst(referenceDate, zone);
                 return (
                   <div
                     key={zone}
                     className={`flex items-center justify-between px-4 py-3 rounded-xl border text-sm ${t.result}`}
                   >
                     <div>
-                      <p className={`font-medium ${t.heading}`}>{zone}</p>
+                      <div className="flex items-center gap-2">
+                        <p className={`font-medium ${t.heading}`}>{zone}</p>
+                        {dst && (
+                          <span
+                            title="This zone is currently observing daylight saving time"
+                            className={`px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide ${
+                              dark
+                                ? "bg-amber-500/20 text-amber-300"
+                                : "bg-amber-100 text-amber-700"
+                            }`}
+                          >
+                            DST
+                          </span>
+                        )}
+                      </div>
                       <p className={`font-mono text-xs mt-0.5 ${t.subtext}`}>
                         {offset}
                       </p>


### PR DESCRIPTION
## 📝 Description
Adds a new **Timezone Converter** utility to the Dev Utilities Sandbox. It's fully client-side (no backend calls), built entirely on the `Intl` API, and follows the existing Dev Utilities design conventions (monochrome, light/dark theme, card + sidebar registration).

Beyond a basic converter, it also includes:
- **World Clock** — pick a source timezone and a date/time (or use live current time), and see that instant converted across a pinnable list of zones, each showing formatted local time and UTC offset.
- **Meeting Overlap Finder** — set a working-hours window (default 09:00–18:00) and the tool shows a 24-hour grid per pinned zone, plus a summary of which UTC hours fall inside working hours for *every* pinned zone simultaneously — answers "is there a time that works for everyone?"
- **Persisted pinned zones** — the pinned zone list is saved to `localStorage` (same pattern as the existing favorite-utilities feature) so it survives page reloads instead of resetting to defaults.
- **DST indicator** — flags any pinned zone currently observing daylight saving time, since a zone's UTC offset silently shifts twice a year and is a common source of scheduling mistakes.

### Files changed
- `src/pages/DevUtilities/devutilities/TimezoneConverter.jsx` (new) — the tool component: conversion logic (`localToUtcIso`, `getOffsetMinutes`), DST detection (`isObservingDst`), the overlap-finder grid (`overlapGrid`, `collapseHourRanges`), and localStorage persistence for pinned zones.
- `src/App.jsx` — imports the component and registers the route `/devutilities/timezone-converter`.
- `src/config/sidebarSections.js` — adds the sidebar nav entry under Dev Utilities.
- `src/pages/DevUtilities/DevUtilities.jsx` — adds the tool's card (title, description, search keywords, icon) to the Dev Utilities home grid.

## 🔗 Related Issue
Closes #193

## 🎯 Type of Change
- [ ] `fix`: Bug fix
- [x] `feat`: New feature
- [ ] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist
- [x] Follows project's **Monochrome** design (Black/Grey/White) 🎨
- [x] Follows [Conventional Commits](https://www.conventionalcommits.org/) 📜
- [x] Added screenshots (if UI was changed) 📸
- [x] Tested locally on the latest version 🧪

## 📸 Screenshots (if applicable)
| Before | After |
<img width="1714" height="1300" alt="image" src="https://github.com/user-attachments/assets/1194efd9-62ae-4925-a9ab-01ae67056472" />
<img width="1508" height="1068" alt="image" src="https://github.com/user-attachments/assets/9a41fb86-2c3d-4f02-a8a5-eb91cd6b1a97" />
<img width="1934" height="1454" alt="image" src="https://github.com/user-attachments/assets/3fe31c93-61b5-42fb-8ff9-5bf55d7fa6d3" />

| | |
