### PR TITLE
feat: add security headers builder utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,14 +115,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -235,13 +235,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -266,18 +266,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -285,9 +285,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -299,32 +299,30 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
+        "@emnapi/wasi-threads": "1.2.3",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -332,9 +330,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -389,9 +387,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -598,29 +596,10 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.139.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
-      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -628,9 +607,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
-      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
       "cpu": [
         "arm64"
       ],
@@ -645,9 +624,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
-      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
       "cpu": [
         "arm64"
       ],
@@ -662,9 +641,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
-      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
       "cpu": [
         "x64"
       ],
@@ -679,9 +658,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
-      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
       "cpu": [
         "x64"
       ],
@@ -696,9 +675,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
-      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
       "cpu": [
         "arm"
       ],
@@ -713,9 +692,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
-      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
       "cpu": [
         "arm64"
       ],
@@ -730,9 +709,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
-      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
       "cpu": [
         "arm64"
       ],
@@ -747,9 +726,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
-      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
       "cpu": [
         "ppc64"
       ],
@@ -764,9 +743,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
-      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
       "cpu": [
         "s390x"
       ],
@@ -781,9 +760,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
-      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
       "cpu": [
         "x64"
       ],
@@ -798,9 +777,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
-      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
       "cpu": [
         "x64"
       ],
@@ -815,9 +794,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
-      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
       "cpu": [
         "arm64"
       ],
@@ -831,52 +810,10 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
-      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
-      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
       "cpu": [
         "arm64"
       ],
@@ -891,9 +828,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
-      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
       "cpu": [
         "x64"
       ],
@@ -1198,17 +1135,6 @@
         "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
       }
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
-      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -1231,10 +1157,10 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1242,9 +1168,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1259,9 +1185,9 @@
       "optional": true
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
-      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1285,9 +1211,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1419,9 +1345,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.43",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
-      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1441,22 +1367,22 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
-      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -1475,11 +1401,11 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001803",
-        "electron-to-chromium": "^1.5.389",
-        "node-releases": "^2.0.51",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1498,9 +1424,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "dev": true,
       "funding": [
         {
@@ -1592,6 +1518,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "deprecated": "Active development of CryptoJS has been discontinued. This library is no longer maintained.",
       "license": "MIT"
     },
     "node_modules/cssesc": {
@@ -1611,7 +1538,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1665,18 +1592,18 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.393",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
-      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
+      "version": "1.5.403",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.403.tgz",
+      "integrity": "sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1687,9 +1614,9 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
-      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1724,9 +1651,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
-      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1737,7 +1664,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -1761,7 +1688,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -1954,9 +1881,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -2032,9 +1959,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -2100,9 +2027,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2231,9 +2158,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -2641,9 +2568,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "18.0.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.6.tgz",
-      "integrity": "sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w==",
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
+      "integrity": "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -2653,13 +2580,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2669,19 +2596,19 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
+      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "3.2.7",
+        "dompurify": "3.4.8",
         "marked": "14.0.0"
       }
     },
     "node_modules/monaco-editor/node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -2707,9 +2634,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2733,9 +2660,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2857,9 +2784,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2878,7 +2805,7 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2951,9 +2878,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -2961,16 +2888,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-icons": {
@@ -2983,9 +2910,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3005,12 +2932,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3060,13 +2987,13 @@
       "license": "ISC"
     },
     "node_modules/rolldown": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
-      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.139.0",
+        "@oxc-project/types": "=0.143.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -3076,21 +3003,20 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.5",
-        "@rolldown/binding-darwin-arm64": "1.1.5",
-        "@rolldown/binding-darwin-x64": "1.1.5",
-        "@rolldown/binding-freebsd-x64": "1.1.5",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
-        "@rolldown/binding-linux-arm64-musl": "1.1.5",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-gnu": "1.1.5",
-        "@rolldown/binding-linux-x64-musl": "1.1.5",
-        "@rolldown/binding-openharmony-arm64": "1.1.5",
-        "@rolldown/binding-wasm32-wasi": "1.1.5",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
-        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3"
       }
     },
     "node_modules/safe-buffer": {
@@ -3157,13 +3083,19 @@
       }
     },
     "node_modules/sonner": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
-      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.8.tgz",
+      "integrity": "sha512-UM/ByIoFra8yzV75n1o0Puu0bw5U/9UNnDacrJNspekBewIfsQ3D6ez1nvlWpt7aTsO6rujQtifBpycwIivqlg==",
       "license": "MIT",
       "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
         "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
         "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/source-map-js": {
@@ -3277,9 +3209,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
       "dev": true,
       "funding": [
         {
@@ -3324,17 +3256,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
-      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "lightningcss": "^1.32.0",
+        "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.17",
-        "rolldown": "~1.1.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -3351,7 +3283,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
+        "@vitejs/devtools": "^0.4.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -3400,6 +3332,267 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/which": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -100,6 +100,7 @@ import MetaTagsGenerator from "./pages/DevUtilities/devutilities/MetaTagsGenerat
 import FaviconGenerator from "./pages/DevUtilities/devutilities/FaviconGenerator";
 import HexInspector from "./pages/DevUtilities/devutilities/HexInspector";
 import KeyPairGenerator from "./pages/DevUtilities/devutilities/KeyPairGenerator";
+import SecurityHeaders from "./pages/DevUtilities/devutilities/SecurityHeadersBuilder";
 
 import Footer from "./components/Footer";
 import Navbar from "./components/Navbar";
@@ -681,6 +682,10 @@ function AppInner({ toggleHUD, hudVisible }) {
               <Route
                 path="/devutilities/keypair-generator"
                 element={<KeyPairGenerator />}
+              />
+              <Route
+                path="/devutilities/security-headers"
+                element={<SecurityHeaders />}
               />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>

--- a/src/config/sidebarSections.js
+++ b/src/config/sidebarSections.js
@@ -492,6 +492,12 @@ const SIDEBAR_SECTIONS = [
           "Design multi-layer box shadows and glows with live preview and copy-ready CSS.",
         path: "/devutilities/box-shadow",
       },
+      {
+        label: "Security Headers Builder",
+        description:
+          "Build and configure HTTP security headers for stronger web application security.",
+        path: "/devutilities/security-headers",
+      },
     ],
   },
 ];

--- a/src/pages/DevUtilities/DevUtilities.jsx
+++ b/src/pages/DevUtilities/DevUtilities.jsx
@@ -1537,6 +1537,33 @@ const DevUtilities = () => {
         </svg>
       ),
     },
+    {
+      title: "Security Headers Builder",
+      description:
+        "Build and configure HTTP security headers for stronger web application security.",
+      path: "/devutilities/security-headers",
+      icon: (
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 3l8 4v5c0 5-3.5 8-8 9-4.5-1-8-4-8-9V7l8-4z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 12l2 2 4-4"
+          />
+        </svg>
+      ),
+    },
   ];
 
   const devUtilsSection = SIDEBAR_SECTIONS.find(

--- a/src/pages/DevUtilities/devutilities/SecurityHeadersBuilder.jsx
+++ b/src/pages/DevUtilities/devutilities/SecurityHeadersBuilder.jsx
@@ -1,0 +1,1469 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { toast } from "sonner";
+import { useTheme } from "../../../context/ThemeContext";
+
+const HEADER_INFO = {
+  contentSecurityPolicy: {
+    label: "Content-Security-Policy",
+    description:
+      "Controls which resources the browser is allowed to load and helps reduce XSS and injection attacks.",
+  },
+  hsts: {
+    label: "Strict-Transport-Security",
+    description:
+      "Tells browsers to use HTTPS for future requests to your domain.",
+  },
+  frameOptions: {
+    label: "X-Frame-Options",
+    description:
+      "Controls whether your site can be embedded inside an iframe.",
+  },
+  contentType: {
+    label: "X-Content-Type-Options",
+    description:
+      "Prevents browsers from MIME-sniffing responses away from their declared content type.",
+  },
+  referrerPolicy: {
+    label: "Referrer-Policy",
+    description:
+      "Controls how much referrer information browsers send with requests.",
+  },
+  permissionsPolicy: {
+    label: "Permissions-Policy",
+    description:
+      "Controls access to browser features such as camera, microphone, and geolocation.",
+  },
+  coop: {
+    label: "Cross-Origin-Opener-Policy",
+    description:
+      "Controls whether your browsing context can share a window group with cross-origin documents.",
+  },
+  corp: {
+    label: "Cross-Origin-Resource-Policy",
+    description:
+      "Controls which origins can load resources from your site.",
+  },
+};
+
+const DEFAULT_SETTINGS = {
+  csp: {
+    enabled: true,
+    defaultSrc: ["'self'"],
+    scriptSrc: ["'self'"],
+    styleSrc: ["'self'"],
+    imgSrc: ["'self", "data:"],
+    fontSrc: ["'self'"],
+    connectSrc: ["'self'"],
+    frameSrc: ["'none'"],
+    objectSrc: ["'none'"],
+  },
+
+  hsts: {
+    enabled: true,
+    maxAge: "31536000",
+    includeSubDomains: true,
+    preload: false,
+  },
+
+  frameOptions: {
+    enabled: true,
+    value: "DENY",
+  },
+
+  contentType: {
+    enabled: true,
+  },
+
+  referrerPolicy: {
+    enabled: true,
+    value: "strict-origin-when-cross-origin",
+  },
+
+  permissionsPolicy: {
+    enabled: true,
+    camera: "'none'",
+    microphone: "'none'",
+    geolocation: "'self'",
+    payment: "'none'",
+  },
+
+  coop: {
+    enabled: true,
+    value: "same-origin",
+  },
+
+  corp: {
+    enabled: true,
+    value: "same-origin",
+  },
+};
+
+const PRESETS = {
+  Basic: {
+    ...DEFAULT_SETTINGS,
+    csp: {
+      ...DEFAULT_SETTINGS.csp,
+      connectSrc: ["'self'", "https:"],
+      imgSrc: ["'self'", "data:", "https:"],
+    },
+    hsts: {
+      ...DEFAULT_SETTINGS.hsts,
+      enabled: false,
+    },
+    permissionsPolicy: {
+      ...DEFAULT_SETTINGS.permissionsPolicy,
+      enabled: false,
+    },
+    coop: {
+      ...DEFAULT_SETTINGS.coop,
+      enabled: false,
+    },
+    corp: {
+      ...DEFAULT_SETTINGS.corp,
+      enabled: false,
+    },
+  },
+
+  SPA: {
+    ...DEFAULT_SETTINGS,
+    csp: {
+      ...DEFAULT_SETTINGS.csp,
+      connectSrc: ["'self'", "https:"],
+      imgSrc: ["'self'", "data:", "blob:", "https:"],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+    },
+  },
+
+  API: {
+    ...DEFAULT_SETTINGS,
+    csp: {
+      ...DEFAULT_SETTINGS.csp,
+      defaultSrc: ["'none'"],
+      scriptSrc: ["'none'"],
+      styleSrc: ["'none'"],
+      imgSrc: ["'none'"],
+      fontSrc: ["'none'"],
+      connectSrc: ["'self'"],
+      frameSrc: ["'none'"],
+      objectSrc: ["'none'"],
+    },
+    frameOptions: {
+      ...DEFAULT_SETTINGS.frameOptions,
+      value: "DENY",
+    },
+    permissionsPolicy: {
+      ...DEFAULT_SETTINGS.permissionsPolicy,
+      enabled: true,
+    },
+  },
+
+  "Production Hardened": {
+    ...DEFAULT_SETTINGS,
+    csp: {
+      ...DEFAULT_SETTINGS.csp,
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'"],
+      imgSrc: ["'self'", "data:", "https:"],
+      fontSrc: ["'self'", "https:"],
+      connectSrc: ["'self'", "https:"],
+      frameSrc: ["'none'"],
+      objectSrc: ["'none'"],
+    },
+    hsts: {
+      enabled: true,
+      maxAge: "63072000",
+      includeSubDomains: true,
+      preload: true,
+    },
+  },
+};
+
+const OUTPUT_FORMATS = [
+  { value: "http", label: "HTTP Headers" },
+  { value: "nginx", label: "Nginx" },
+  { value: "apache", label: "Apache" },
+  { value: "express", label: "Express.js" },
+  { value: "vercel", label: "Vercel" },
+];
+
+const cloneSettings = (settings) => JSON.parse(JSON.stringify(settings));
+
+const quoteForConfig = (value) => value.replace(/"/g, '\\"');
+
+const joinCspDirective = (name, values) => {
+  if (!values || values.length === 0) return "";
+  return `${name} ${values.join(" ")}`;
+};
+
+const buildCsp = (csp) => {
+  const directives = [
+    joinCspDirective("default-src", csp.defaultSrc),
+    joinCspDirective("script-src", csp.scriptSrc),
+    joinCspDirective("style-src", csp.styleSrc),
+    joinCspDirective("img-src", csp.imgSrc),
+    joinCspDirective("font-src", csp.fontSrc),
+    joinCspDirective("connect-src", csp.connectSrc),
+    joinCspDirective("frame-src", csp.frameSrc),
+    joinCspDirective("object-src", csp.objectSrc),
+  ].filter(Boolean);
+
+  return directives.join("; ");
+};
+
+const buildHeaders = (settings) => {
+  const headers = [];
+
+  if (settings.csp.enabled) {
+    headers.push({
+      name: "Content-Security-Policy",
+      value: buildCsp(settings.csp),
+    });
+  }
+
+  if (settings.hsts.enabled) {
+    let value = `max-age=${settings.hsts.maxAge}`;
+
+    if (settings.hsts.includeSubDomains) {
+      value += "; includeSubDomains";
+    }
+
+    if (settings.hsts.preload) {
+      value += "; preload";
+    }
+
+    headers.push({
+      name: "Strict-Transport-Security",
+      value,
+    });
+  }
+
+  if (settings.frameOptions.enabled) {
+    headers.push({
+      name: "X-Frame-Options",
+      value: settings.frameOptions.value,
+    });
+  }
+
+  if (settings.contentType.enabled) {
+    headers.push({
+      name: "X-Content-Type-Options",
+      value: "nosniff",
+    });
+  }
+
+  if (settings.referrerPolicy.enabled) {
+    headers.push({
+      name: "Referrer-Policy",
+      value: settings.referrerPolicy.value,
+    });
+  }
+
+  if (settings.permissionsPolicy.enabled) {
+    const permissions = [
+      `camera=${settings.permissionsPolicy.camera}`,
+      `microphone=${settings.permissionsPolicy.microphone}`,
+      `geolocation=${settings.permissionsPolicy.geolocation}`,
+      `payment=${settings.permissionsPolicy.payment}`,
+    ];
+
+    headers.push({
+      name: "Permissions-Policy",
+      value: permissions.join(", "),
+    });
+  }
+
+  if (settings.coop.enabled) {
+    headers.push({
+      name: "Cross-Origin-Opener-Policy",
+      value: settings.coop.value,
+    });
+  }
+
+  if (settings.corp.enabled) {
+    headers.push({
+      name: "Cross-Origin-Resource-Policy",
+      value: settings.corp.value,
+    });
+  }
+
+  return headers;
+};
+
+const generateOutput = (headers, format) => {
+  if (format === "http") {
+    return headers.map((header) => `${header.name}: ${header.value}`).join("\n");
+  }
+
+  if (format === "nginx") {
+    return headers
+      .map(
+        (header) =>
+          `add_header ${header.name} "${quoteForConfig(header.value)}" always;`
+      )
+      .join("\n");
+  }
+
+  if (format === "apache") {
+    return headers
+      .map(
+        (header) =>
+          `Header always set ${header.name} "${quoteForConfig(header.value)}"`
+      )
+      .join("\n");
+  }
+
+  if (format === "express") {
+    return headers
+      .map(
+        (header) =>
+          `res.setHeader("${header.name}", "${quoteForConfig(header.value)}");`
+      )
+      .join("\n");
+  }
+
+  if (format === "vercel") {
+    return JSON.stringify(
+      {
+        headers: [
+          {
+            source: "/(.*)",
+            headers: headers.map((header) => ({
+              key: header.name,
+              value: header.value,
+            })),
+          },
+        ],
+      },
+      null,
+      2
+    );
+  }
+
+  return "";
+};
+
+const calculateScore = (settings) => {
+  let score = 0;
+
+  if (settings.csp.enabled) score += 25;
+  if (settings.hsts.enabled) score += 15;
+  if (settings.frameOptions.enabled) score += 10;
+  if (settings.contentType.enabled) score += 10;
+  if (settings.referrerPolicy.enabled) score += 10;
+  if (settings.permissionsPolicy.enabled) score += 10;
+  if (settings.coop.enabled) score += 5;
+  if (settings.corp.enabled) score += 5;
+
+  if (
+    settings.csp.enabled &&
+    settings.csp.scriptSrc.includes("'unsafe-inline'")
+  ) {
+    score -= 5;
+  }
+
+  if (
+    settings.csp.enabled &&
+    settings.csp.scriptSrc.includes("'unsafe-eval'")
+  ) {
+    score -= 5;
+  }
+
+  if (
+    settings.hsts.enabled &&
+    settings.hsts.maxAge === "0"
+  ) {
+    score -= 10;
+  }
+
+  return Math.max(0, Math.min(100, score));
+};
+
+const getScoreLabel = (score) => {
+  if (score >= 90) {
+    return {
+      label: "Excellent",
+      color: "text-emerald-500",
+    };
+  }
+
+  if (score >= 75) {
+    return {
+      label: "Strong",
+      color: "text-green-500",
+    };
+  }
+
+  if (score >= 50) {
+    return {
+      label: "Moderate",
+      color: "text-yellow-500",
+    };
+  }
+
+  return {
+    label: "Needs work",
+    color: "text-red-500",
+  };
+};
+
+const getRecommendations = (settings) => {
+  const recommendations = [];
+
+  if (!settings.csp.enabled) {
+    recommendations.push({
+      type: "warning",
+      text: "Add a Content-Security-Policy to control which resources browsers can load.",
+    });
+  }
+
+  if (!settings.hsts.enabled) {
+    recommendations.push({
+      type: "warning",
+      text: "Enable HSTS when your website is served exclusively over HTTPS.",
+    });
+  }
+
+  if (!settings.permissionsPolicy.enabled) {
+    recommendations.push({
+      type: "warning",
+      text: "Consider adding Permissions-Policy to restrict browser features.",
+    });
+  }
+
+  if (
+    settings.csp.enabled &&
+    settings.csp.scriptSrc.includes("'unsafe-inline'")
+  ) {
+    recommendations.push({
+      type: "warning",
+      text: "Avoid 'unsafe-inline' in script-src where possible. Prefer nonces or hashes.",
+    });
+  }
+
+  if (
+    settings.csp.enabled &&
+    settings.csp.scriptSrc.includes("'unsafe-eval'")
+  ) {
+    recommendations.push({
+      type: "warning",
+      text: "Avoid 'unsafe-eval' in script-src unless your application specifically requires it.",
+    });
+  }
+
+  if (
+    settings.hsts.enabled &&
+    Number(settings.hsts.maxAge) < 31536000
+  ) {
+    recommendations.push({
+      type: "warning",
+      text: "For production HSTS, consider a max-age of at least one year.",
+    });
+  }
+
+  if (recommendations.length === 0) {
+    recommendations.push({
+      type: "success",
+      text: "Your configuration includes a strong baseline of common security headers.",
+    });
+  }
+
+  return recommendations;
+};
+
+const Toggle = ({ enabled, onChange, dark }) => (
+  <button
+    type="button"
+    onClick={() => onChange(!enabled)}
+    aria-pressed={enabled}
+    className={`relative w-11 h-6 rounded-full shrink-0 transition-colors duration-200 focus:outline-none ${
+      enabled
+        ? dark
+          ? "bg-white"
+          : "bg-black"
+        : dark
+        ? "bg-zinc-700"
+        : "bg-neutral-300"
+    }`}
+  >
+    <span
+      className={`absolute top-0.5 w-5 h-5 rounded-full shadow-md transition-all duration-200 ${
+        enabled ? "right-0.5" : "left-0.5"
+      } ${enabled && dark ? "bg-black" : "bg-white"}`}
+    />
+  </button>
+);
+
+const SectionHeader = ({ title, description, enabled, onToggle, dark }) => (
+  <div className="flex items-start justify-between gap-4">
+    <div className="min-w-0">
+      <h3
+        className={`text-sm font-black uppercase tracking-wide ${
+          dark ? "text-white" : "text-black"
+        }`}
+      >
+        {title}
+      </h3>
+
+      <p
+        className={`mt-1 text-xs leading-relaxed ${
+          dark ? "text-zinc-500" : "text-neutral-500"
+        }`}
+      >
+        {description}
+      </p>
+    </div>
+
+    {typeof enabled === "boolean" && onToggle && (
+      <Toggle enabled={enabled} onChange={onToggle} dark={dark} />
+    )}
+  </div>
+);
+
+const SecurityHeadersBuilder = () => {
+  const { dark } = useTheme();
+
+  const [settings, setSettings] = useState(() =>
+    cloneSettings(DEFAULT_SETTINGS)
+  );
+
+  const [outputFormat, setOutputFormat] = useState("http");
+
+  const headers = useMemo(
+    () => buildHeaders(settings),
+    [settings]
+  );
+
+  const output = useMemo(
+    () => generateOutput(headers, outputFormat),
+    [headers, outputFormat]
+  );
+
+  const score = useMemo(
+    () => calculateScore(settings),
+    [settings]
+  );
+
+  const scoreInfo = getScoreLabel(score);
+
+  const recommendations = useMemo(
+    () => getRecommendations(settings),
+    [settings]
+  );
+
+  const updateSection = (section, updates) => {
+    setSettings((current) => ({
+      ...current,
+      [section]: {
+        ...current[section],
+        ...updates,
+      },
+    }));
+  };
+
+  const updatePermission = (key, value) => {
+    setSettings((current) => ({
+      ...current,
+      permissionsPolicy: {
+        ...current.permissionsPolicy,
+        [key]: value,
+      },
+    }));
+  };
+
+  const addCspSource = (directive, source) => {
+    const cleanSource = source.trim();
+
+    if (!cleanSource) return;
+
+    setSettings((current) => {
+      const existing = current.csp[directive] || [];
+
+      if (existing.includes(cleanSource)) {
+        return current;
+      }
+
+      return {
+        ...current,
+        csp: {
+          ...current.csp,
+          [directive]: [...existing, cleanSource],
+        },
+      };
+    });
+  };
+
+  const removeCspSource = (directive, source) => {
+    setSettings((current) => ({
+      ...current,
+      csp: {
+        ...current.csp,
+        [directive]: current.csp[directive].filter(
+          (item) => item !== source
+        ),
+      },
+    }));
+  };
+
+  const applyPreset = (presetName) => {
+    setSettings(cloneSettings(PRESETS[presetName]));
+    toast.success(`${presetName} preset applied`);
+  };
+
+  const reset = () => {
+    setSettings(cloneSettings(DEFAULT_SETTINGS));
+    setOutputFormat("http");
+    toast.success("Configuration reset");
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(output);
+      toast.success("Configuration copied to clipboard");
+    } catch {
+      toast.error("Failed to copy configuration");
+    }
+  };
+
+  const inputClass = `w-full px-3 py-2 rounded-xl border text-xs outline-none transition-all duration-300 ${
+    dark
+      ? "bg-zinc-950 border-zinc-800 text-white placeholder-zinc-600 focus:border-white focus:ring-1 focus:ring-white"
+      : "bg-white border-neutral-300 text-black placeholder-neutral-400 focus:border-black focus:ring-1 focus:ring-black"
+  }`;
+
+  const selectClass = `px-3 py-2 rounded-xl border text-xs outline-none transition-all ${
+    dark
+      ? "bg-zinc-950 border-zinc-800 text-zinc-200 focus:border-white"
+      : "bg-white border-neutral-300 text-neutral-800 focus:border-black"
+  }`;
+
+  const labelClass = `text-[11px] font-black uppercase tracking-widest ${
+    dark ? "text-zinc-500" : "text-neutral-400"
+  }`;
+
+  const panelClass = `rounded-2xl border p-4 ${
+    dark
+      ? "bg-zinc-950/50 border-zinc-800/80"
+      : "bg-neutral-50 border-neutral-200/85"
+  }`;
+
+  const softBtnClass = `rounded-xl border px-3 py-1.5 text-xs font-black uppercase tracking-widest transition-all duration-200 ${
+    dark
+      ? "bg-zinc-800 border-zinc-700 text-zinc-300 hover:text-white hover:border-zinc-500"
+      : "bg-white border-neutral-200 text-zinc-600 hover:text-black hover:border-neutral-400"
+  }`;
+
+  const primaryBtnClass = `rounded-xl border px-6 py-3 text-xs font-black uppercase tracking-widest transition-all duration-200 hover:scale-105 ${
+    dark
+      ? "bg-white text-black border-white hover:bg-zinc-200"
+      : "bg-black text-white border-black hover:bg-zinc-800"
+  }`;
+
+  const presetChipClass = (active = false) =>
+    `inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-widest border transition-colors ${
+      active
+        ? dark
+          ? "border-white text-black bg-white"
+          : "border-black text-white bg-black"
+        : dark
+        ? "border-zinc-800 text-zinc-400 hover:text-white hover:border-zinc-700"
+        : "border-neutral-200 text-neutral-500 hover:text-black hover:border-neutral-300"
+    }`;
+
+  // CSP source values ('self', data:, https://...) are literal syntax, not labels —
+  // never text-transformed, always shown in monospace like the header value blocks below.
+  const sourceChipClass = `inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-mono border transition-colors ${
+    dark
+      ? "border-zinc-700 text-zinc-200 bg-zinc-800"
+      : "border-neutral-300 text-neutral-800 bg-neutral-100"
+  }`;
+
+  // Inline field labels paired with a control (Max Age, Camera, Microphone...) —
+  // matches the reference's "Delimiter" label: plain case, not a standalone section label.
+  const fieldLabelClass = `text-xs font-semibold ${
+    dark ? "text-zinc-300" : "text-neutral-700"
+  }`;
+
+  return (
+    <div
+      className={`min-h-[calc(100vh-76px)] px-4 sm:px-6 py-6 transition-colors duration-300 overflow-y-auto overflow-x-hidden relative ${
+        dark ? "bg-zinc-950" : "bg-[#F7F7F7]"
+      }`}
+    >
+      {/* Decorative background */}
+      <div
+        className={`absolute top-[-10%] right-[-10%] w-[300px] sm:w-[500px] h-[300px] sm:h-[500px] rounded-full blur-[100px] opacity-30 transition-colors duration-500 ${
+          dark ? "bg-zinc-800" : "bg-neutral-200"
+        }`}
+      />
+
+      <div
+        className={`absolute bottom-[-10%] left-[-10%] w-[300px] sm:w-[500px] h-[300px] sm:h-[500px] rounded-full blur-[100px] opacity-30 transition-colors duration-500 ${
+          dark ? "bg-zinc-900" : "bg-neutral-100"
+        }`}
+      />
+
+      {/* Main card */}
+      <div
+        className={`relative z-10 w-full max-w-7xl mx-auto rounded-[32px] border shadow-xl flex flex-col overflow-hidden transition-all duration-300 ${
+          dark
+            ? "bg-zinc-900 border-zinc-800"
+            : "bg-white border-neutral-200"
+        }`}
+      >
+        {/* Accent bar */}
+        <div
+          className={`h-2 w-full ${
+            dark ? "bg-white" : "bg-black"
+          }`}
+        />
+
+        {/* Header */}
+        <div className="px-5 sm:px-8 pt-6 sm:pt-8 flex items-center gap-3">
+          <Link
+            to="/devutilities"
+            className={`p-2.5 rounded-xl border transition-all duration-200 active:scale-95 flex items-center justify-center shrink-0 ${
+              dark
+                ? "bg-zinc-800/80 border-zinc-700 text-zinc-300 hover:text-white hover:border-zinc-600"
+                : "bg-white border-neutral-200 text-neutral-600 hover:text-black hover:border-neutral-300"
+            }`}
+            title="Back to Workspace"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2.5}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </Link>
+
+          <div className="min-w-0 flex-1">
+            <h1
+              className={`text-xl sm:text-2xl font-black uppercase tracking-tight ${
+                dark ? "text-white" : "text-black"
+              }`}
+            >
+              Security Headers Builder
+            </h1>
+
+            <p
+              className={`mt-1 text-xs ${
+                dark ? "text-zinc-500" : "text-neutral-500"
+              }`}
+            >
+              Build common web security headers and generate deployment-ready
+              configuration.
+            </p>
+          </div>
+
+          <button
+            onClick={reset}
+            className={`hidden sm:block ${softBtnClass}`}
+          >
+            Reset
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="px-5 sm:px-8 pt-5 pb-6 sm:pb-8">
+          {/* Presets */}
+          <div className={`${panelClass} mb-4`}>
+            <div className="flex flex-wrap items-center gap-3">
+              <span className={labelClass}>Presets</span>
+
+              <div className="flex flex-wrap gap-1.5">
+                {Object.keys(PRESETS).map((preset) => (
+                  <button
+                    key={preset}
+                    onClick={() => applyPreset(preset)}
+                    className={presetChipClass()}
+                  >
+                    {preset}
+                  </button>
+                ))}
+              </div>
+
+              <button
+                onClick={reset}
+                className={`ml-auto text-xs font-black uppercase tracking-widest sm:hidden ${
+                  dark
+                    ? "text-zinc-400 hover:text-white"
+                    : "text-neutral-500 hover:text-black"
+                }`}
+              >
+                Reset
+              </button>
+            </div>
+          </div>
+
+          {/* Two-column workspace */}
+          <div className="grid grid-cols-1 xl:grid-cols-[1.15fr_0.85fr] gap-4">
+            {/* LEFT: Configuration */}
+            <div className="space-y-4">
+              {/* CSP */}
+              <div className={panelClass}>
+                <SectionHeader
+                  title={HEADER_INFO.contentSecurityPolicy.label}
+                  description={HEADER_INFO.contentSecurityPolicy.description}
+                  enabled={settings.csp.enabled}
+                  onToggle={(value) =>
+                    updateSection("csp", { enabled: value })
+                  }
+                  dark={dark}
+                />
+
+                {settings.csp.enabled && (
+                  <div className="mt-4 space-y-3">
+                    {[
+                      ["defaultSrc", "default-src"],
+                      ["scriptSrc", "script-src"],
+                      ["styleSrc", "style-src"],
+                      ["imgSrc", "img-src"],
+                      ["fontSrc", "font-src"],
+                      ["connectSrc", "connect-src"],
+                      ["frameSrc", "frame-src"],
+                      ["objectSrc", "object-src"],
+                    ].map(([key, label]) => (
+                      <CspDirective
+                        key={key}
+                        label={label}
+                        sources={settings.csp[key]}
+                        dark={dark}
+                        sourceChipClass={sourceChipClass}
+                        inputClass={inputClass}
+                        onAdd={(source) => addCspSource(key, source)}
+                        onRemove={(source) =>
+                          removeCspSource(key, source)
+                        }
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* HSTS */}
+              <div className={panelClass}>
+                <SectionHeader
+                  title={HEADER_INFO.hsts.label}
+                  description={HEADER_INFO.hsts.description}
+                  enabled={settings.hsts.enabled}
+                  onToggle={(value) =>
+                    updateSection("hsts", { enabled: value })
+                  }
+                  dark={dark}
+                />
+
+                {settings.hsts.enabled && (
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mt-4">
+                    <div>
+                      <label className={fieldLabelClass}>Max Age</label>
+                      <input
+                        type="number"
+                        min="0"
+                        value={settings.hsts.maxAge}
+                        onChange={(e) =>
+                          updateSection("hsts", {
+                            maxAge: e.target.value,
+                          })
+                        }
+                        className={`${inputClass} mt-2`}
+                      />
+                    </div>
+
+                    <label
+                      className={`flex items-center gap-2 cursor-pointer text-xs ${
+                        dark ? "text-zinc-300" : "text-neutral-700"
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={settings.hsts.includeSubDomains}
+                        onChange={(e) =>
+                          updateSection("hsts", {
+                            includeSubDomains: e.target.checked,
+                          })
+                        }
+                        className={dark ? "accent-white" : "accent-black"}
+                      />
+                      Include subdomains
+                    </label>
+
+                    <label
+                      className={`flex items-center gap-2 cursor-pointer text-xs ${
+                        dark ? "text-zinc-300" : "text-neutral-700"
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={settings.hsts.preload}
+                        onChange={(e) =>
+                          updateSection("hsts", {
+                            preload: e.target.checked,
+                          })
+                        }
+                        className={dark ? "accent-white" : "accent-black"}
+                      />
+                      Preload
+                    </label>
+                  </div>
+                )}
+              </div>
+
+              {/* Other headers */}
+              <div className={panelClass}>
+                <div className="mb-4">
+                  <h3
+                    className={`text-sm font-black uppercase tracking-wide ${
+                      dark ? "text-white" : "text-black"
+                    }`}
+                  >
+                    Browser Security Controls
+                  </h3>
+
+                  <p
+                    className={`mt-1 text-xs ${
+                      dark ? "text-zinc-500" : "text-neutral-500"
+                    }`}
+                  >
+                    Configure additional commonly used response headers.
+                  </p>
+                </div>
+
+                <div className="space-y-4">
+                  {/* X-Frame-Options */}
+                  <div
+                    className={`rounded-xl border p-3 ${
+                      dark
+                        ? "border-zinc-800 bg-zinc-900"
+                        : "border-neutral-200 bg-white"
+                    }`}
+                  >
+                    <SectionHeader
+                      title={HEADER_INFO.frameOptions.label}
+                      description={HEADER_INFO.frameOptions.description}
+                      enabled={settings.frameOptions.enabled}
+                      onToggle={(value) =>
+                        updateSection("frameOptions", {
+                          enabled: value,
+                        })
+                      }
+                      dark={dark}
+                    />
+
+                    {settings.frameOptions.enabled && (
+                      <select
+                        value={settings.frameOptions.value}
+                        onChange={(e) =>
+                          updateSection("frameOptions", {
+                            value: e.target.value,
+                          })
+                        }
+                        className={`${selectClass} mt-3`}
+                      >
+                        <option value="DENY">DENY</option>
+                        <option value="SAMEORIGIN">SAMEORIGIN</option>
+                      </select>
+                    )}
+                  </div>
+
+                  {/* Content type */}
+                  <div
+                    className={`rounded-xl border p-3 ${
+                      dark
+                        ? "border-zinc-800 bg-zinc-900"
+                        : "border-neutral-200 bg-white"
+                    }`}
+                  >
+                    <SectionHeader
+                      title={HEADER_INFO.contentType.label}
+                      description={HEADER_INFO.contentType.description}
+                      enabled={settings.contentType.enabled}
+                      onToggle={(value) =>
+                        updateSection("contentType", {
+                          enabled: value,
+                        })
+                      }
+                      dark={dark}
+                    />
+                  </div>
+
+                  {/* Referrer Policy */}
+                  <div
+                    className={`rounded-xl border p-3 ${
+                      dark
+                        ? "border-zinc-800 bg-zinc-900"
+                        : "border-neutral-200 bg-white"
+                    }`}
+                  >
+                    <SectionHeader
+                      title={HEADER_INFO.referrerPolicy.label}
+                      description={HEADER_INFO.referrerPolicy.description}
+                      enabled={settings.referrerPolicy.enabled}
+                      onToggle={(value) =>
+                        updateSection("referrerPolicy", {
+                          enabled: value,
+                        })
+                      }
+                      dark={dark}
+                    />
+
+                    {settings.referrerPolicy.enabled && (
+                      <select
+                        value={settings.referrerPolicy.value}
+                        onChange={(e) =>
+                          updateSection("referrerPolicy", {
+                            value: e.target.value,
+                          })
+                        }
+                        className={`${selectClass} mt-3 w-full sm:w-auto`}
+                      >
+                        <option value="no-referrer">no-referrer</option>
+                        <option value="strict-origin">
+                          strict-origin
+                        </option>
+                        <option value="strict-origin-when-cross-origin">
+                          strict-origin-when-cross-origin
+                        </option>
+                        <option value="same-origin">same-origin</option>
+                        <option value="origin">origin</option>
+                        <option value="no-referrer-when-downgrade">
+                          no-referrer-when-downgrade
+                        </option>
+                      </select>
+                    )}
+                  </div>
+
+                  {/* Permissions Policy */}
+                  <div
+                    className={`rounded-xl border p-3 ${
+                      dark
+                        ? "border-zinc-800 bg-zinc-900"
+                        : "border-neutral-200 bg-white"
+                    }`}
+                  >
+                    <SectionHeader
+                      title={HEADER_INFO.permissionsPolicy.label}
+                      description={HEADER_INFO.permissionsPolicy.description}
+                      enabled={settings.permissionsPolicy.enabled}
+                      onToggle={(value) =>
+                        updateSection("permissionsPolicy", {
+                          enabled: value,
+                        })
+                      }
+                      dark={dark}
+                    />
+
+                    {settings.permissionsPolicy.enabled && (
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
+                        {[
+                          ["camera", "Camera"],
+                          ["microphone", "Microphone"],
+                          ["geolocation", "Geolocation"],
+                          ["payment", "Payment"],
+                        ].map(([key, label]) => (
+                          <div key={key}>
+                            <label className={fieldLabelClass}>{label}</label>
+
+                            <select
+                              value={settings.permissionsPolicy[key]}
+                              onChange={(e) =>
+                                updatePermission(
+                                  key,
+                                  e.target.value
+                                )
+                              }
+                              className={`${selectClass} mt-2 w-full`}
+                            >
+                              <option value="'none'">None</option>
+                              <option value="'self'">Self</option>
+                              <option value="*">All origins</option>
+                            </select>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* COOP */}
+                  <div
+                    className={`rounded-xl border p-3 ${
+                      dark
+                        ? "border-zinc-800 bg-zinc-900"
+                        : "border-neutral-200 bg-white"
+                    }`}
+                  >
+                    <SectionHeader
+                      title={HEADER_INFO.coop.label}
+                      description={HEADER_INFO.coop.description}
+                      enabled={settings.coop.enabled}
+                      onToggle={(value) =>
+                        updateSection("coop", { enabled: value })
+                      }
+                      dark={dark}
+                    />
+
+                    {settings.coop.enabled && (
+                      <select
+                        value={settings.coop.value}
+                        onChange={(e) =>
+                          updateSection("coop", {
+                            value: e.target.value,
+                          })
+                        }
+                        className={`${selectClass} mt-3`}
+                      >
+                        <option value="same-origin">same-origin</option>
+                        <option value="same-origin-allow-popups">
+                          same-origin-allow-popups
+                        </option>
+                        <option value="unsafe-none">unsafe-none</option>
+                      </select>
+                    )}
+                  </div>
+
+                  {/* CORP */}
+                  <div
+                    className={`rounded-xl border p-3 ${
+                      dark
+                        ? "border-zinc-800 bg-zinc-900"
+                        : "border-neutral-200 bg-white"
+                    }`}
+                  >
+                    <SectionHeader
+                      title={HEADER_INFO.corp.label}
+                      description={HEADER_INFO.corp.description}
+                      enabled={settings.corp.enabled}
+                      onToggle={(value) =>
+                        updateSection("corp", { enabled: value })
+                      }
+                      dark={dark}
+                    />
+
+                    {settings.corp.enabled && (
+                      <select
+                        value={settings.corp.value}
+                        onChange={(e) =>
+                          updateSection("corp", {
+                            value: e.target.value,
+                          })
+                        }
+                        className={`${selectClass} mt-3`}
+                      >
+                        <option value="same-origin">same-origin</option>
+                        <option value="same-site">same-site</option>
+                        <option value="cross-origin">
+                          cross-origin
+                        </option>
+                      </select>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* RIGHT: Score + Output */}
+            <div className="space-y-4">
+              {/* Score */}
+              <div className={panelClass}>
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <span className={labelClass}>Security Score</span>
+
+                    <div className="flex items-baseline gap-2 mt-1">
+                      <span
+                        className={`text-4xl font-black ${
+                          dark ? "text-white" : "text-black"
+                        }`}
+                      >
+                        {score}
+                      </span>
+
+                      <span
+                        className={`text-sm font-bold ${
+                          dark ? "text-zinc-400" : "text-neutral-500"
+                        }`}
+                      >
+                        / 100
+                      </span>
+                    </div>
+                  </div>
+
+                  <div
+                    className={`px-3 py-1.5 rounded-full text-[10px] font-black uppercase tracking-widest border ${
+                      score >= 75
+                        ? dark
+                          ? "border-white text-black bg-white"
+                          : "border-black text-white bg-black"
+                        : score >= 50
+                        ? dark
+                          ? "border-zinc-600 text-zinc-300"
+                          : "border-neutral-300 text-neutral-600"
+                        : "border-red-500/60 text-red-500 bg-red-500/10"
+                    }`}
+                  >
+                    {scoreInfo.label}
+                  </div>
+                </div>
+
+                <div
+                  className={`mt-4 h-2 rounded-full overflow-hidden ${
+                    dark ? "bg-zinc-800" : "bg-neutral-200"
+                  }`}
+                >
+                  <div
+                    className={`h-full rounded-full transition-all duration-500 ${
+                      score >= 50
+                        ? dark
+                          ? "bg-white"
+                          : "bg-black"
+                        : "bg-red-500"
+                    }`}
+                    style={{ width: `${score}%` }}
+                  />
+                </div>
+
+                <div className="mt-4 space-y-2">
+                  {recommendations.map((recommendation, index) => (
+                    <div
+                      key={index}
+                      className={`flex gap-2 text-xs leading-relaxed ${
+                        dark ? "text-zinc-400" : "text-neutral-600"
+                      }`}
+                    >
+                      <span
+                        className={
+                          recommendation.type === "success"
+                            ? dark
+                              ? "text-white"
+                              : "text-black"
+                            : "text-red-500"
+                        }
+                      >
+                        {recommendation.type === "success" ? "✓" : "!"}
+                      </span>
+
+                      <span>{recommendation.text}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Active headers */}
+              <div className={panelClass}>
+                <div className="flex items-center justify-between mb-3">
+                  <span className={labelClass}>
+                    Generated Headers
+                  </span>
+
+                  <span
+                    className={`text-[10px] font-semibold ${
+                      dark ? "text-zinc-600" : "text-neutral-400"
+                    }`}
+                  >
+                    {headers.length} active
+                  </span>
+                </div>
+
+                <div className="space-y-2">
+                  {headers.map((header) => (
+                    <div
+                      key={header.name}
+                      className={`rounded-xl border px-3 py-2 ${
+                        dark
+                          ? "border-zinc-800 bg-zinc-900"
+                          : "border-neutral-200 bg-white"
+                      }`}
+                    >
+                      <div
+                        className={`text-[10px] font-bold ${
+                          dark ? "text-zinc-300" : "text-neutral-700"
+                        }`}
+                      >
+                        {header.name}
+                      </div>
+
+                      <div
+                        className={`mt-1 text-[10px] font-mono break-all ${
+                          dark ? "text-zinc-500" : "text-neutral-500"
+                        }`}
+                      >
+                        {header.value}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Output */}
+              <div className="flex flex-col min-h-[420px]">
+                <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+                  <label className={labelClass}>
+                    Configuration Output
+                  </label>
+
+                  <div className="flex gap-2">
+                    <select
+                      value={outputFormat}
+                      onChange={(e) =>
+                        setOutputFormat(e.target.value)
+                      }
+                      className={selectClass}
+                    >
+                      {OUTPUT_FORMATS.map((format) => (
+                        <option
+                          key={format.value}
+                          value={format.value}
+                        >
+                          {format.label}
+                        </option>
+                      ))}
+                    </select>
+
+                    <button
+                      onClick={handleCopy}
+                      className={softBtnClass}
+                    >
+                      Copy
+                    </button>
+                  </div>
+                </div>
+
+                <div className="relative flex-1 flex flex-col rounded-2xl overflow-hidden border bg-[#0D1117] border-zinc-800 shadow-inner min-h-[320px]">
+                  <div className="flex items-center gap-2 px-4 py-3 bg-[#161B22] border-b border-zinc-800">
+                    <div className="w-3 h-3 rounded-full bg-red-500/80" />
+                    <div className="w-3 h-3 rounded-full bg-yellow-500/80" />
+                    <div className="w-3 h-3 rounded-full bg-green-500/80" />
+
+                    <span className="ml-2 text-[10px] text-zinc-500 font-mono">
+                      {OUTPUT_FORMATS.find(
+                        (item) => item.value === outputFormat
+                      )?.label || "HTTP Headers"}
+                    </span>
+                  </div>
+
+                  <pre className="flex-1 p-5 overflow-auto font-mono text-[11px] sm:text-xs text-emerald-400 whitespace-pre-wrap leading-relaxed custom-scrollbar">
+                    {output}
+                  </pre>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Footer note */}
+          <div
+            className={`mt-4 rounded-2xl border px-4 py-3 text-xs leading-relaxed ${
+              dark
+                ? "border-zinc-800 bg-zinc-950 text-zinc-500"
+                : "border-neutral-200 bg-neutral-50 text-neutral-500"
+            }`}
+          >
+            <strong
+              className={dark ? "text-zinc-300" : "text-neutral-700"}
+            >
+              Note:
+            </strong>{" "}
+            This tool generates a practical baseline configuration. Security
+            headers should still be tested against your application's actual
+            resources and deployment environment before production use.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const CspDirective = ({
+  label,
+  sources,
+  dark,
+  sourceChipClass,
+  inputClass,
+  onAdd,
+  onRemove,
+}) => {
+  const [value, setValue] = useState("");
+
+  const handleAdd = () => {
+    const cleanValue = value.trim();
+
+    if (!cleanValue) return;
+
+    onAdd(cleanValue);
+    setValue("");
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      handleAdd();
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-2 mb-2">
+        <span
+          className={`text-[10px] font-mono font-bold ${
+            dark ? "text-zinc-300" : "text-neutral-700"
+          }`}
+        >
+          {label}
+        </span>
+
+        <div className="flex flex-wrap gap-1.5">
+          {sources.map((source) => (
+            <span
+              key={source}
+              className={sourceChipClass}
+            >
+              {source}
+
+              <button
+                type="button"
+                onClick={() => onRemove(source)}
+                className="ml-0.5 opacity-60 hover:opacity-100"
+                aria-label={`Remove ${source}`}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Add source, e.g. https://cdn.example.com"
+          className={inputClass}
+        />
+
+        <button
+          type="button"
+          onClick={handleAdd}
+          className={`px-3 rounded-xl border text-xs font-semibold shrink-0 transition-colors ${
+            dark
+              ? "bg-zinc-800 border-zinc-700 text-zinc-300 hover:bg-zinc-700 hover:text-white"
+              : "bg-white border-neutral-200 text-neutral-700 hover:bg-neutral-100"
+          }`}
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SecurityHeadersBuilder;


### PR DESCRIPTION
Adds a Security Headers Builder utility — configure CSP, HSTS, X-Frame-Options, Referrer-Policy, Permissions-Policy, COOP, and CORP, with output in HTTP/Nginx/Apache/Express/Vercel formats, presets, and a scoring panel with recommendations. Relates to #193.'
<img width="1765" height="918" alt="Screenshot 2026-08-11 002548" src="https://github.com/user-attachments/assets/17d75456-bf55-46e3-89a6-101fc92ffc5e" />
[
<img width="1760" height="920" alt="Screenshot 2026-08-11 002742" src="https://github.com/user-attachments/assets/b8468e43-f5d8-44d1-b6b4-c553e482eda0" />
]