### PR TITLE
fix: use syntax highlighted editor for JSON-LD output

### DIFF
--- a/src/pages/DevUtilities/devutilities/JsonLdGenerator.jsx
+++ b/src/pages/DevUtilities/devutilities/JsonLdGenerator.jsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback } from "react";
+import { Editor } from "@monaco-editor/react";
 import { Link } from "react-router-dom";
 import { toast } from "sonner";
 import { useTheme } from "../../../context/ThemeContext";
@@ -797,11 +798,12 @@ export default function JsonLdGenerator() {
                 </div>
               </div>
               <div className="relative flex-1 flex flex-col min-h-[420px]">
-                <textarea
-                  readOnly
-                  value={scriptBlock}
-                  spellCheck={false}
-                  className={`w-full flex-1 rounded-2xl p-4 font-mono text-xs leading-relaxed resize-none outline-none border transition-colors duration-200 ${t.outputTextarea}`}
+                <Editor
+                height="100%"
+                language="json"
+                theme={dark ? "vs-dark" : "light"}
+                value={scriptBlock}
+                options={{ readOnly: true, minimap: { enabled: false }, lineNumbers: "on", wordWrap: "on", folding: true, scrollBeyondLastLine: false, automaticLayout: true, fontSize: 12, padding: { top: 16, bottom: 16, },}}
                 />
               </div>
               <p className={`text-[10px] font-semibold ${t.label}`}>


### PR DESCRIPTION
## 📖 Description

Replaced the read-only textarea used for JSON-LD output with the existing Monaco Editor component.

This provides syntax highlighting and a more consistent code-editor experience while keeping the generated JSON-LD output read-only.

## 🔗 Related Issue

Related to #445

## 🎯 Type of Change

- [x] `fix`: Bug fix
- [ ] `feat`: New feature
- [ ] `style`: UI/Theme changes (Monochrome)
- [ ] `chore`: Build/Maintenance

## ✅ Checklist

- [x] Follows project's **Monochrome** design
- [x] Uses the existing Monaco Editor component
- [x] JSON-LD output remains read-only
- [x] Supports light and dark themes
- [x] Tested all 5 JSON-LD schema types
- [x] Tested locally with `npm run build`
- [x] `git diff --check` passes

## 🧪 Testing

- `npm run build` ✅
- `git diff upstream/main...HEAD --check` ✅
- Manually verified JSON-LD output for:
  - Local Business
  - Article / Blog Post
  - Product
  - FAQ Page
  - Breadcrumb List

## 📸 Screenshots

The JSON-LD output is now displayed in a syntax-highlighted, read-only Monaco Editor.